### PR TITLE
Reduce tests for exit status

### DIFF
--- a/tests/test-exit-status
+++ b/tests/test-exit-status
@@ -2,7 +2,7 @@
 dumb_init="$1"
 
 # dumb-init should exit with the same exit status as the process it launches.
-for i in $(seq 0 255); do
+for i in 0 1 2 32 64 127 254 255; do
     status=$($dumb_init sh -c "exit $i"; echo $?)
 
     if [ "$status" -ne "$i" ]; then


### PR DESCRIPTION
I don't think we really need to test all 256 exit statuses; this test takes a while (especially on CI) and generates a ton of unnecessary output.