### PR TITLE
Compile dumb-init with -O3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-std=gnu99 -static -Wall -Werror
+CFLAGS=-std=gnu99 -static -Wall -Werror -O3
 
 TEST_PACKAGE_DEPS := python python-pip
 


### PR DESCRIPTION
Because dumb-init is too slow currently.