### PR TITLE
Run tox in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,17 @@
     sha: 003e43251aea1da33f2072f2365ec8b9ceaae070
     hooks:
     -   id: autopep8-wrapper
-        language_version: python2.7
     -   id: check-added-large-files
     -   id: check-docstring-first
-        language_version: python2.7
     -   id: check-json
     -   id: check-merge-conflict
     -   id: check-xml
     -   id: check-yaml
     -   id: debug-statements
-        language_version: python2.7
     -   id: detect-private-key
     -   id: double-quote-string-fixer
-        language_version: python2.7
     -   id: end-of-file-fixer
     -   id: flake8
-        language_version: python2.7
     -   id: name-tests-test
         exclude: ^tests/lib
     -   id: requirements-txt-fixer
@@ -26,7 +21,6 @@
     sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
     hooks:
     -   id: reorder-python-imports
-        language_version: python2.7
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
     sha: 181a63c511691da58116fa19a7241956018660bc
     hooks:

--- a/CI/circle
+++ b/CI/circle
@@ -21,6 +21,7 @@ TARGETS = [
     'itest_wheezy',
     'itest_jessie',
     'itest_stretch',
+    'itest_tox',
 ]
 
 

--- a/tests/tty_test.py
+++ b/tests/tty_test.py
@@ -12,15 +12,6 @@ def ttyflags(fd):
     T.tcsetattr(fd, T.TCSANOW, attrs)
 
 
-def tac():
-    """
-    run tac. if it fails to complete in 1 second send SIGKILL and exit with an
-    error.
-    """
-    from os import execvp
-    execvp('timeout', ('timeout', '1', 'dumb-init', 'tac'))
-
-
 def readall(fd):
     """read until EOF"""
     from os import read
@@ -58,6 +49,7 @@ def test_tty(debug_disabled):
     import pty
     pid, fd = pty.fork()
     if pid == 0:
-        tac()
+        from os import execvp
+        execvp('dumb-init', ('dumb-init', 'tac'))
     else:
         _test(fd)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27,py34
+envlist = py26,py27,py34
 
 [testenv]
-deps = -rrequirements-dev.txt
+deps = -r{toxinidir}/requirements-dev.txt
 commands =
     python -m pytest
     pre-commit run --all-files


### PR DESCRIPTION
This ensures `tox` actually passes, and tries it with py26/27/34. Currently nothing in CI actually tests tox.

This also unpins language versions for pre-commit since we need to support tests in all of those versions anyway.