### PR TITLE
Properly respond to job control signals

### DIFF
--- a/tests/lib/print_signals.py
+++ b/tests/lib/print_signals.py
@@ -11,10 +11,14 @@ import signal
 import sys
 import time
 
-from tests.lib.testing import CATCHABLE_SIGNALS
+
+CATCHABLE_SIGNALS = frozenset(
+    set(range(1, 32)) - set([signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD])
+)
 
 
 print_queue = []
+last_signal = None
 
 
 def unbuffered_print(line):
@@ -35,6 +39,12 @@ if __name__ == '__main__':
     # loop forever just printing signals
     while True:
         if print_queue:
-            unbuffered_print(print_queue.pop())
+            signum = print_queue.pop()
+            unbuffered_print(signum)
+
+            if signum == signal.SIGINT and last_signal == signal.SIGINT:
+                print('Received SIGINT twice, exiting.')
+                exit(0)
+            last_signal = signum
 
         time.sleep(0.01)

--- a/tests/proxies_signals_test.py
+++ b/tests/proxies_signals_test.py
@@ -5,11 +5,12 @@ import sys
 from subprocess import PIPE
 from subprocess import Popen
 
-from tests.lib.testing import CATCHABLE_SIGNALS
+from tests.lib.testing import NORMAL_SIGNALS
 from tests.lib.testing import pid_tree
 
 
 def test_prints_signals(both_debug_modes, both_setsid_modes):
+    """Ensure dumb-init proxies regular signals to its child."""
     proc = Popen(
         ('dumb-init', sys.executable, '-m', 'tests.lib.print_signals'),
         stdout=PIPE,
@@ -17,7 +18,7 @@ def test_prints_signals(both_debug_modes, both_setsid_modes):
 
     assert re.match(b'^ready \(pid: (?:[0-9]+)\)\n$', proc.stdout.readline())
 
-    for signum in CATCHABLE_SIGNALS:
+    for signum in NORMAL_SIGNALS:
         proc.send_signal(signum)
         assert proc.stdout.readline() == '{0}\n'.format(signum).encode('ascii')
 

--- a/tests/shell_background_test.py
+++ b/tests/shell_background_test.py
@@ -1,0 +1,82 @@
+import os
+import re
+import sys
+import time
+from signal import SIGCONT
+from signal import SIGKILL
+from subprocess import PIPE
+from subprocess import Popen
+
+from tests.lib.testing import pid_tree
+from tests.lib.testing import process_state
+from tests.lib.testing import SUSPEND_SIGNALS
+
+
+def test_shell_background_support_setsid(both_debug_modes, setsid_enabled):
+    """In setsid mode, dumb-init should suspend itself and its children when it
+    receives SIGTSTP, SIGTTOU, or SIGTTIN.
+    """
+    proc = Popen(
+        ('dumb-init', sys.executable, '-m', 'tests.lib.print_signals'),
+        stdout=PIPE,
+    )
+    match = re.match(b'^ready \(pid: ([0-9]+)\)\n$', proc.stdout.readline())
+    pid = match.group(1).decode('ascii')
+
+    for signum in SUSPEND_SIGNALS:
+        # both dumb-init and print_signals should be running or sleeping
+        assert process_state(pid) in ['running', 'sleeping']
+        assert process_state(proc.pid) in ['running', 'sleeping']
+
+        # both should now suspend
+        proc.send_signal(signum)
+
+        for _ in range(1000):
+            time.sleep(0.001)
+            try:
+                assert process_state(proc.pid) == 'stopped'
+                assert process_state(pid) == 'stopped'
+            except AssertionError:
+                pass
+            else:
+                break
+        else:
+            raise RuntimeError('Timed out waiting for processes to stop.')
+
+        # and then both wake up again
+        proc.send_signal(SIGCONT)
+        assert (
+            proc.stdout.readline() == '{0}\n'.format(SIGCONT).encode('ascii')
+        )
+        assert process_state(pid) in ['running', 'sleeping']
+        assert process_state(proc.pid) in ['running', 'sleeping']
+
+    for pid in pid_tree(proc.pid):
+        os.kill(pid, SIGKILL)
+
+
+def test_prints_signals(both_debug_modes, setsid_disabled):
+    """In non-setsid mode, dumb-init should forward the signals SIGTSTP,
+    SIGTTOU, and SIGTTIN, and then suspend itself.
+    """
+    proc = Popen(
+        ('dumb-init', sys.executable, '-m', 'tests.lib.print_signals'),
+        stdout=PIPE,
+    )
+
+    assert re.match(b'^ready \(pid: (?:[0-9]+)\)\n$', proc.stdout.readline())
+
+    for signum in SUSPEND_SIGNALS:
+        assert process_state(proc.pid) in ['running', 'sleeping']
+        proc.send_signal(signum)
+        assert proc.stdout.readline() == '{0}\n'.format(signum).encode('ascii')
+        assert process_state(proc.pid) == 'stopped'
+
+        proc.send_signal(SIGCONT)
+        assert (
+            proc.stdout.readline() == '{0}\n'.format(SIGCONT).encode('ascii')
+        )
+        assert process_state(proc.pid) in ['running', 'sleeping']
+
+    for pid in pid_tree(proc.pid):
+        os.kill(pid, SIGKILL)


### PR DESCRIPTION
@bukzor @kentwills 

This ended up being more complicated than expected; I spent some time understanding exactly what's going on here (including a bunch of back-and-forth with a friendly stranger in freenode ##linux and some diving into the kernel source).

### `SIGTSTP` vs `SIGSTOP`

`SIGTSTP` is the signal generated when you press Ctrl-Z in a shell; it's a nicer version of `SIGSTOP` which processes can catch and respond to (or not). The default behavior implemented in the kernel is to suspend when receiving the signal in normal cases.

The approach from #19 is to proxy `SIGTSTP` to dumb-init's children when received, then send `SIGSTOP` to dumb-init from itself. This works well for processes which register a custom `SIGTSTP` handler, but not well for processes which don't.

### Problems with just forwarding `SIGTSTP`

The kernel [won't apply the default signal handling](https://github.com/torvalds/linux/blob/v4.2/kernel/signal.c#L2296-L2299) to an "orphaned process group".

> A process group is called orphaned when the parent of every member is either in the process group or outside the session. In particular, **the process group of the session leader is always orphaned**.
> (from https://www.win.tue.nl/~aeb/linux/lk/lk-10.html)

(The session leader is always `dumb-init`'s child process.)

In other words, your `SIGTSTP` will do nothing when dumb-init is running in setsid mode, unless your process registers custom signal handlers. You can replicate this with a simple Python script (or an equivalent C program if you prefer):

```python
#!/usr/bin/env python
import time
while True:
    print('oh, hi')
    time.sleep(1)
```

`dumb-init` will suspend and tell you it has forwarded `SIGTSTP`, but the Python process won't suspend. If you add a `SIGTSTP` handler to the Python process, you'll notice that it actually *does* receive that signal, but in the default case the process won't suspend.

### How we can avoid that

A couple options:

1. Always send `SIGSTOP` when running in setsid mode. This does work, but it means processes can't choose to do cleanup before suspending. That's what this branch does currently.

2. Patch the kernel. The following patch fixes the issue (and probably introduces hundreds of new issues in unrelated areas):

    ```patch
diff --git a/kernel/signal.c b/kernel/signal.c
index a4077e9..7770471 100644
--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -2302,7 +2302,7 @@ relock:
 				/* signals can be posted during this window */
 
 				if (is_current_pgrp_orphaned())
-					goto relock;
+					printk(KERN_WARNING "suspending process despite orphaned process group, this is probably a bad idea!\n");
 
 				spin_lock_irq(&sighand->siglock);
 			}
```

    Obviously, this is not a serious suggestion.... but it does work.

3. ??? (I think I have an idea, testing it now.)

**Still needs tests.**