### PR TITLE
Redesign process management model

### DIFF
--- a/tests/lib/print_signals.py
+++ b/tests/lib/print_signals.py
@@ -11,10 +11,14 @@ import signal
 import sys
 import time
 
-from tests.lib.testing import CATCHABLE_SIGNALS
+
+CATCHABLE_SIGNALS = frozenset(
+    set(range(1, 32)) - set([signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD])
+)
 
 
 print_queue = []
+last_signal = None
 
 
 def unbuffered_print(line):
@@ -35,6 +39,12 @@ if __name__ == '__main__':
     # loop forever just printing signals
     while True:
         if print_queue:
-            unbuffered_print(print_queue.pop())
+            signum = print_queue.pop()
+            unbuffered_print(signum)
+
+            if signum == signal.SIGINT and last_signal == signal.SIGINT:
+                print('Received SIGINT twice, exiting.')
+                exit(0)
+            last_signal = signum
 
         time.sleep(0.01)


### PR DESCRIPTION
Current issues:

* When used interactively from a shell like `dumb-init ./tests/lib/print_signals.py`, if you `^C` the child processes will receive `INT` twice: once because the shell signals the entire process group, and one again when dumb-init proxies the signal to the process group.

* When used in a script like

        #!/bin/bash -eux
        dumb-init ./tests/lib/print_signals.py

   hitting `^C` has no effect at all.