### PR TITLE
Prefix output with [dumb-init]

### DIFF
--- a/tests/child_processes_test.py
+++ b/tests/child_processes_test.py
@@ -131,6 +131,6 @@ def test_fails_nonzero_with_bad_exec(both_debug_modes, both_setsid_modes):
     proc.wait()
     assert proc.returncode != 0
     assert (
-        b'dumb-init: /doesnotexist: No such file or directory\n'
+        b'[dumb-init] /doesnotexist: No such file or directory\n'
         in proc.stderr
     )


### PR DESCRIPTION
This fixes #35 

Example debug output:

```
ckuehl@dev15-devc:~/proj/dumb-init$ ./dumb-init boo
[dumb-init] boo: No such file or directory
ckuehl@dev15-devc:~/proj/dumb-init$ ./dumb-init echo hi
hi
ckuehl@dev15-devc:~/proj/dumb-init$ DUMB_INIT_DEBUG=1 ./dumb-init echo hi
[dumb-init] Running in debug mode.
[dumb-init] Child spawned with PID 783282.
[dumb-init] setsid complete.
hi
[dumb-init] A child with PID 783282 exited with exit status 0.
[dumb-init] Forwarded signal 15 to children.
[dumb-init] Child exited with status 0. Goodbye.
```