### PR TITLE
Don't run tests interactively or with a TTY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS=-std=gnu99 -static -Wall -Werror -O3
 
 TEST_PACKAGE_DEPS := python python-pip
 
-DOCKER_RUN_TEST := docker run -ti -v $(PWD):/mnt:ro
+DOCKER_RUN_TEST := docker run -v $(PWD):/mnt:ro
 
 # test installation using Debian packages
 DOCKER_DEB_TEST := sh -euxc ' \


### PR DESCRIPTION
This results in errors on Jenkins like:

    10:28:35 time="2015-10-22T10:28:36-07:00" level=fatal msg="cannot enable tty mode on non tty input" 

We don't actually need a TTY or interactive mode, so I think this is quite reasonable.