### PR TITLE
Simplify release a bit, also provide just binaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ The process to release a new version is:
 3. Update the two `wget` urls in the README to point to the new version.
 4. Commit the changes and tag the commit like `v1.0.0`.
 5. `git push --tags origin master`
-6. Run `make clean && make release`
-7. Run `twine upload dist/*.tar.gz` to upload the new version to PyPI
+6. Run `make release`
+7. Run `twine upload --skip-existing dist/*.tar.gz` to upload the new version
+   to PyPI
 8. Run `make builddeb-docker` and upload the resulting Debian package and
-   binary to a new [GitHub release](https://github.com/Yelp/dumb-init/releases)
+   binary (inside the `dist` directory) to a new [GitHub
+   release](https://github.com/Yelp/dumb-init/releases)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,11 @@ of that after merging!
 The process to release a new version is:
 
 1. Update the version in `VERSION`
-2. Run `make VERSION.h`
 2. Update the Debian changelog with `dch -v {new version}`.
-3. Update the `wget` url in the README to point to the new version.
+3. Update the two `wget` urls in the README to point to the new version.
 4. Commit the changes and tag the commit like `v1.0.0`.
 5. `git push --tags origin master`
-6. Run `rm -rf dist && python setup.py sdist` to create a source distribution
-7. Run `twine upload dist/*` to upload the new version to PyPI
-8. Run `make builddeb-docker` and upload the resulting Debian package to a new
-   [GitHub release](https://github.com/Yelp/dumb-init/releases)
+6. Run `make clean && make release`
+7. Run `twine upload dist/*.tar.gz` to upload the new version to PyPI
+8. Run `make builddeb-docker` and upload the resulting Debian package and
+   binary to a new [GitHub release](https://github.com/Yelp/dumb-init/releases)

--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,26 @@ clean: clean-tox
 clean-tox:
 	rm -rf .tox
 
+.PHONY: release
+release: builddeb-docker sdist
+	# extract the built binary from the Debian package
+	dpkg-deb --fsys-tarfile dist/dumb-init_$(shell cat VERSION)_amd64.deb | \
+		tar -C dist --strip=3 -xvf - ./usr/bin/dumb-init
+	mv dist/dumb-init dist/dumb-init_$(shell cat VERSION)_amd64
+
+.PHONY: sdist
+sdist: VERSION.h
+	python setup.py sdist
+
 .PHONY: builddeb
 builddeb:
 	debuild --set-envvar=CC=musl-gcc -us -uc -b
-	rm -rf dist && mkdir dist
+	mkdir -p dist
 	mv ../dumb-init_*.deb dist/
 
 .PHONY: builddeb-docker
 builddeb-docker: docker-image
+	mkdir -p dist
 	docker run -v $(PWD):/mnt dumb-init-build
 
 .PHONY: docker-image

--- a/README.md
+++ b/README.md
@@ -135,7 +135,18 @@ RUN dpkg -i dumb-init_*.deb
 ```
 
 
-### Option 3: Installing from PyPI
+### Option 3: Downloading the binary directly
+
+Since dumb-init is released as a statically-linked binary, you can usually just
+plop it into your images. Here's an example of doing that in a Dockerfile:
+
+```bash
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v0.5.0/dumb-init_0.5.0_amd64
+RUN chmod +x /usr/local/bin/dumb-init
+```
+
+
+### Option 4: Installing from PyPI
 
 Though `dumb-init` is written entirely in C, we also provide a Python package
 which compiles and installs the binary. It can be installed [from

--- a/debian/rules
+++ b/debian/rules
@@ -10,3 +10,6 @@ override_dh_auto_test:
 	find . -name '__pycache__' -delete
 	PATH=.:$$PATH py.test tests/
 	ps aux
+
+# we don't want it to wipe out our dist directory
+override_dh_auto_clean:


### PR DESCRIPTION
This resolves #45 by extracting the built binary from the Debian package and sticking it in `dist` to be uploaded.

I already uploaded binaries for previous releases at https://github.com/Yelp/dumb-init/releases