### PR TITLE
Fix stretch itest missing "ps" command, use pipefail to catch it earlier in the future

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS=-std=gnu99 -static -Wall -Werror -O3
 
-TEST_PACKAGE_DEPS := python python-pip
+TEST_PACKAGE_DEPS := python python-pip procps
 
 DOCKER_RUN_TEST := docker run -v $(PWD):/mnt:ro
 

--- a/tests/test-zombies
+++ b/tests/test-zombies
@@ -6,11 +6,12 @@
 # We run it as the last step of the integration tests inside our Docker
 # containers. Since dumb-init must run as PID 1, we don't use pytest and
 # instead write it in bash (which gets executed by PID1 dumb-init).
+set -o pipefail
 
 bash -euxc "bash -euxc 'echo i am a zombie' &" &
 
 sleep 1
-num_zombies=$(ps -A -o state | grep 'Z' | wc -l)
+num_zombies=$(ps -A -o state | (grep 'Z' || true) | wc -l)
 
 if [ "$num_zombies" -ne 0 ]; then
     echo "Expected no zombies, but instead there were ${num_zombies}."


### PR DESCRIPTION
The test was failing but not generating a nonzero status code because pipefail wasn't on.

Previously it looked like this:

```bash
+ exec dumb-init /mnt/tests/test-zombies
+ sleep 1
+ bash -euxc 'bash -euxc '\''echo i am a zombie'\'' &'
+ bash -euxc 'echo i am a zombie'
+ echo i am a zombie
i am a zombie
++ ps -A -o state
++ grep Z
/mnt/tests/test-zombies: line 13: ps: command not found
++ wc -l
+ num_zombies=0
+ '[' 0 -ne 0 ']'

Target itest_stretch completed successfully
```

(stretch is unreleased and something of a moving target, so it's not totally unexpected that something like this might happen -- but obviously the tests should have caught it!)