### PR TITLE
Handle adopted children

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -39,7 +39,7 @@ void forward_signal(int signum) {
     int pid;
 
     if (child_pid > 0) {
-        pid = use_setsid ? -1 : child_pid;
+        pid = use_setsid ? (getpid() == 1 ? -1 : -child_pid) : child_pid;
         kill(pid, signum);
         DEBUG("Forwarded signal %d to %d from pid %d.\n", signum, pid, getpid());
     } else {

--- a/dumb-init.c
+++ b/dumb-init.c
@@ -252,7 +252,7 @@ int main(int argc, char *argv[]) {
 
                 // single_child or not init, then leave!
                 if (!use_setsid || getpid() != 1) {
-                    DEBUG("Goodbye\n");
+                    DEBUG("Goodbye.\n");
                     exit(exit_status);
                 }
 

--- a/dumb-init.c
+++ b/dumb-init.c
@@ -33,11 +33,15 @@
 pid_t child_pid = -1;
 char debug = 0;
 char use_setsid = 1;
+int signal_forwarded = 0;
 
 void forward_signal(int signum) {
+    int pid;
+
     if (child_pid > 0) {
-        kill(use_setsid ? -child_pid : child_pid, signum);
-        DEBUG("Forwarded signal %d to children.\n", signum);
+        pid = use_setsid ? (getpid() == 1 ? -1 : -child_pid) : child_pid;
+        kill(pid, signum);
+        DEBUG("Forwarded signal %d to %d from pid %d.\n", signum, pid, getpid());
     } else {
         DEBUG("Didn't forward signal %d, no children exist yet.\n", signum);
     }
@@ -97,6 +101,8 @@ void handle_signal(int signum) {
     } else {
         forward_signal(signum);
     }
+
+    signal_forwarded = 1;
 }
 
 void print_help(char *argv[]) {
@@ -212,7 +218,7 @@ int main(int argc, char *argv[]) {
         exit(2);
     } else {
         pid_t killed_pid;
-        int exit_status, status;
+        int child_exit_status = 0, exit_status, status;
 
         DEBUG("Child spawned with PID %d.\n", child_pid);
 
@@ -220,13 +226,39 @@ int main(int argc, char *argv[]) {
             exit_status = WEXITSTATUS(status);
             DEBUG("A child with PID %d exited with exit status %d.\n", killed_pid, exit_status);
 
-            if (killed_pid == child_pid) {
-                // send SIGTERM to any remaining children
-                forward_signal(SIGTERM);
+            if (killed_pid == -1) {
+                if (errno == 10) {
+                    DEBUG("No more child processes to wait for. Exiting.\n");
+                    exit_status = child_exit_status;
+                } else {
+                    PRINTERR(
+                        "waitpid (errno=%d %s). Exiting.\n",
+                        errno,
+                        strerror(errno)
+                    );
+                }
 
-                DEBUG("Child exited with status %d. Goodbye.\n", exit_status);
                 exit(exit_status);
+
+            } else if (killed_pid == child_pid) {
+
+                DEBUG("Child exited with status %d.\n", exit_status);
+
+                // Direct child exited, send SIGTERM to any remaining children
+                // if not using single_child mode and not done already
+                if (use_setsid && !signal_forwarded) {
+                    forward_signal(SIGTERM);
+                }
+
+                // single_child or not init, then leave!
+                if (!use_setsid || getpid() != 1) {
+                    DEBUG("Goodbye\n");
+                    exit(exit_status);
+                }
+
+                child_exit_status = exit_status;
             }
+
         }
     }
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -72,7 +72,8 @@ def test_verbose(flag):
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
             b'\[dumb-init\] Child exited with status 0\.\n'
             b'\[dumb-init\] Forwarded signal 15 to [-0-9]+ from pid [0-9]+\.\n'
-            b'\[dumb-init\] Goodbye\.\n$'
+            b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
+            b'\[dumb-init\] No more child processes to wait for\. Exiting\.\n$'
         ),
         stderr,
     )
@@ -91,7 +92,8 @@ def test_verbose_and_single_child(flag1, flag2):
             b'^\[dumb-init\] Child spawned with PID [0-9]+\.\n'
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
             b'\[dumb-init\] Child exited with status 0\.\n'
-            b'\[dumb-init\] Goodbye\.\n$'
+            b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
+            b'\[dumb-init\] No more child processes to wait for\. Exiting\.\n$'
         ),
         stderr,
     )

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -70,8 +70,10 @@ def test_verbose(flag):
             b'^\[dumb-init\] Child spawned with PID [0-9]+\.\n'
             b'\[dumb-init\] setsid complete\.\n'
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
-            b'\[dumb-init\] Forwarded signal 15 to children\.\n'
-            b'\[dumb-init\] Child exited with status 0\. Goodbye\.\n$'
+            b'\[dumb-init\] Child exited with status 0\.\n'
+            b'\[dumb-init\] Forwarded signal 15 to [-0-9]+ from pid [0-9]+\.\n'
+            b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
+            b'\[dumb-init\] No more child processes to wait for\. Exiting\.\n$'
         ),
         stderr,
     )
@@ -89,8 +91,8 @@ def test_verbose_and_single_child(flag1, flag2):
         (
             b'^\[dumb-init\] Child spawned with PID [0-9]+\.\n'
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
-            b'\[dumb-init\] Forwarded signal 15 to children\.\n'
-            b'\[dumb-init\] Child exited with status 0\. Goodbye\.\n$'
+            b'\[dumb-init\] Child exited with status 0\.\n'
+            b'\[dumb-init\] Goodbye\.\n$'
         ),
         stderr,
     )

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -72,8 +72,7 @@ def test_verbose(flag):
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
             b'\[dumb-init\] Child exited with status 0\.\n'
             b'\[dumb-init\] Forwarded signal 15 to [-0-9]+ from pid [0-9]+\.\n'
-            b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
-            b'\[dumb-init\] No more child processes to wait for\. Exiting\.\n$'
+            b'\[dumb-init\] Goodbye\.\n$'
         ),
         stderr,
     )


### PR DESCRIPTION
**Background:**
When a process backgrounds itself it is adopted by PID 1.
Dumb-init originally only forwards signals to every process in the process group of its children, or only to its first children if provided in the options (--single-child).
In this scenario it does not take care of background processes, therefore signals are not forwarded to them and no time is given for them to perform cleanup before exiting.

**Changes:**
* Fordward signals to adopted childs if running as PID 1.
* Wait for all childs to exit before terminating instead of exiting as soon as direct child does if running as PID 1.
* Do not forward signals when direct child exits if already done (i.e. dumb-init received the signal from Docker