### PR TITLE
Fix signal terminated processes exit code

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -217,8 +217,14 @@ int main(int argc, char *argv[]) {
         DEBUG("Child spawned with PID %d.\n", child_pid);
 
         while ((killed_pid = waitpid(-1, &status, 0))) {
-            exit_status = WEXITSTATUS(status);
-            DEBUG("A child with PID %d exited with exit status %d.\n", killed_pid, exit_status);
+            if (WIFEXITED(status)) {
+                exit_status = WEXITSTATUS(status);
+                DEBUG("A child with PID %d exited with exit status %d.\n", killed_pid, exit_status);
+            } else {
+                assert(WIFSIGNALED(status));
+                exit_status = 128 + WTERMSIG(status);
+                DEBUG("A child with PID %d was terminated by signal %d.\n", killed_pid, exit_status - 128);
+            }
 
             if (killed_pid == child_pid) {
                 // send SIGTERM to any remaining children

--- a/tests/exit_status_test.py
+++ b/tests/exit_status_test.py
@@ -1,11 +1,29 @@
+import signal
 from subprocess import Popen
 
+import pytest
 
-def test_exit_status(both_debug_modes, both_setsid_modes):
+
+@pytest.mark.parametrize('exit_status', [0, 1, 2, 32, 64, 127, 254, 255])
+def test_exit_status_regular_exit(exit_status, both_debug_modes, both_setsid_modes):
     """dumb-init should exit with the same exit status as the process that it
-    supervises.
+    supervises when that process exits normally.
     """
-    for status in [0, 1, 2, 32, 64, 127, 254, 255]:
-        proc = Popen(('dumb-init', 'sh', '-c', 'exit {0}'.format(status)))
-        proc.wait()
-        assert proc.returncode == status
+    proc = Popen(('dumb-init', 'sh', '-c', 'exit {0}'.format(exit_status)))
+    proc.wait()
+    assert proc.returncode == exit_status
+
+
+@pytest.mark.parametrize('signal', [
+    signal.SIGTERM,
+    signal.SIGINT,
+    signal.SIGQUIT,
+    signal.SIGKILL,
+])
+def test_exit_status_terminated_by_signal(signal, both_debug_modes, both_setsid_modes):
+    """dumb-init should exit with status 128 + signal when the child process is
+    terminated by a signal.
+    """
+    proc = Popen(('dumb-init', 'sh', '-c', 'kill -{0} $$'.format(signal)))
+    proc.wait()
+    assert proc.returncode == 128 + signal

--- a/tests/lib/testing.py
+++ b/tests/lib/testing.py
@@ -12,9 +12,9 @@ SUSPEND_SIGNALS = frozenset([
 ])
 
 NORMAL_SIGNALS = frozenset(
-    set(range(1, 32))
-    - set([signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD])
-    - SUSPEND_SIGNALS
+    set(range(1, 32)) -
+    set([signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD]) -
+    SUSPEND_SIGNALS
 )
 
 


### PR DESCRIPTION
Previously, dumb-init handled exit codes wrong when the child was terminated via signal (rather than exiting normally), as reported by @msavage20 in #59.

Broken behavior from before:
```bash
ckuehl@neon:~$ sh -c 'kill -TERM $$'
ckuehl@neon:~$ echo $?
143
ckuehl@neon:~$ dumb-init sh -c 'kill -TERM $$'
ckuehl@neon:~$ echo $?
0
```