### PR TITLE
Upload SHA256 checksums of releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Code is reviewed using GitHub pull requests. To make a contribution, you should:
 2. Push code to a branch on your fork
 3. Create a pull request and wait for it to be reviewed
 
+We aim to have all dumb-init behavior covered by tests. If you make a change in
+behavior, please add a test to ensure it doesn't regress. We're also happy to
+help with suggestions on testing!
+
 
 ## Releasing new versions
 
@@ -27,5 +31,6 @@ The process to release a new version is:
 6. `git push --tags origin master`
 7. Run `twine upload --skip-existing dist/*.tar.gz` to upload the new version
    to PyPI
-8. Upload the resulting Debian package and binary (inside the `dist` directory)
-   to a new [GitHub release](https://github.com/Yelp/dumb-init/releases)
+8. Upload the resulting Debian package, binary (inside the `dist` directory),
+   and sha256sums file to a new [GitHub
+   release](https://github.com/Yelp/dumb-init/releases)

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,14 @@ clean-tox:
 
 .PHONY: release
 release: builddeb-docker sdist
+	$(eval VERSION := $(shell cat VERSION))
 	# extract the built binary from the Debian package
-	dpkg-deb --fsys-tarfile dist/dumb-init_$(shell cat VERSION)_amd64.deb | \
+	dpkg-deb --fsys-tarfile dist/dumb-init_$(VERSION)_amd64.deb | \
 		tar -C dist --strip=3 -xvf - ./usr/bin/dumb-init
-	mv dist/dumb-init dist/dumb-init_$(shell cat VERSION)_amd64
+	mv dist/dumb-init dist/dumb-init_$(VERSION)_amd64
+	cd dist && \
+		sha256sum dumb-init_$(VERSION)_amd64.deb dumb-init_$(VERSION)_amd64 \
+		> sha256sums
 
 .PHONY: sdist
 sdist: VERSION.h


### PR DESCRIPTION
Fixes #61 

This produces a file like:
```
91b9970e6a0d23d7aedf3321fb1d161937e7f5e6ff38c51a8a997278cc00fb0a  dumb-init_1.0.1_amd64
41c6a808df35f0033966471953657d080ad662eff25e28d32d8f8dc3b6812ebe  dumb-init_1.0.1_amd64.deb
```

...which we can upload to the GitHub "releases" tab.