### PR TITLE
fix: calculate SHA256 hash value in binary mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ release: builddeb-docker sdist
 		tar -C dist --strip=3 -xvf - ./usr/bin/dumb-init
 	mv dist/dumb-init dist/dumb-init_$(VERSION)_amd64
 	cd dist && \
-		sha256sum dumb-init_$(VERSION)_amd64.deb dumb-init_$(VERSION)_amd64 \
+		sha256sum --binary dumb-init_$(VERSION)_amd64.deb dumb-init_$(VERSION)_amd64 \
 		> sha256sums
 
 .PHONY: sdist


### PR DESCRIPTION
Correctness fix. This change will not make a difference on Unix. See https://www.virtualbox.org/ticket/9569.