### PR TITLE
Add Ubuntu xenial itest, test Python 3.5, fix some test bitrot

### DIFF
--- a/CI/circle
+++ b/CI/circle
@@ -18,6 +18,7 @@ TARGETS = [
     'itest_lucid',
     'itest_precise',
     'itest_trusty',
+    'itest_xenial',
     'itest_wheezy',
     'itest_jessie',
     'itest_stretch',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34
+envlist = py26,py27,py34,py35
 
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
* Add `itest_xenial`
* Switch `itest_tox` to use xenial instead of trusty
* Add python3.5 tox
* Fixes some bitrot in the test suite (latest pre-commit deps pyterminalsize which is a C extension, so we need compilers and python-dev packages in all the containers that we use pre-commit in).

Debian packages are still built on jessie (but it doesn't really matter, because we test that they can install and pass tests on all the systems we care about).