### PR TITLE
Fix flaky job control tests

### DIFF
--- a/tests/proxies_signals_test.py
+++ b/tests/proxies_signals_test.py
@@ -9,7 +9,7 @@ from tests.lib.testing import NORMAL_SIGNALS
 from tests.lib.testing import pid_tree
 
 
-def test_prints_signals(both_debug_modes, both_setsid_modes):
+def test_proxies_signals(both_debug_modes, both_setsid_modes):
     """Ensure dumb-init proxies regular signals to its child."""
     proc = Popen(
         ('dumb-init', sys.executable, '-m', 'tests.lib.print_signals'),

--- a/tests/shell_background_test.py
+++ b/tests/shell_background_test.py
@@ -55,7 +55,7 @@ def test_shell_background_support_setsid(both_debug_modes, setsid_enabled):
         os.kill(pid, SIGKILL)
 
 
-def test_prints_signals(both_debug_modes, setsid_disabled):
+def test_shell_background_support_without_setsid(both_debug_modes, setsid_disabled):
     """In non-setsid mode, dumb-init should forward the signals SIGTSTP,
     SIGTTOU, and SIGTTIN, and then suspend itself.
     """
@@ -70,6 +70,7 @@ def test_prints_signals(both_debug_modes, setsid_disabled):
         assert process_state(proc.pid) in ['running', 'sleeping']
         proc.send_signal(signum)
         assert proc.stdout.readline() == '{0}\n'.format(signum).encode('ascii')
+        os.waitpid(proc.pid, os.WUNTRACED)
         assert process_state(proc.pid) == 'stopped'
 
         proc.send_signal(SIGCONT)


### PR DESCRIPTION
This fixes #67

Right now there's a race condition in this test (dumb-init might not actually suspend in time before our check). We can fix that by using `wait` to wait for it to put itself to sleep.

We can almost do this to the test above (which uses sleep in a loop), but we can't wait on grandchildren. (Maybe dumb-init should wait for its child to go to sleep when it forwards SIGSTOP?)