### PR TITLE
Simplify signal handling using sigwait, eliminate some undefined behavior

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -69,6 +69,7 @@ def test_verbose(flag):
         (
             b'^\[dumb-init\] Child spawned with PID [0-9]+\.\n'
             b'\[dumb-init\] setsid complete\.\n'
+            b'\[dumb-init\] Received signal 17\.\n'
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
             b'\[dumb-init\] Forwarded signal 15 to children\.\n'
             b'\[dumb-init\] Child exited with status 0\. Goodbye\.\n$'
@@ -88,6 +89,7 @@ def test_verbose_and_single_child(flag1, flag2):
     assert re.match(
         (
             b'^\[dumb-init\] Child spawned with PID [0-9]+\.\n'
+            b'\[dumb-init\] Received signal 17\.\n'
             b'\[dumb-init\] A child with PID [0-9]+ exited with exit status 0.\n'
             b'\[dumb-init\] Forwarded signal 15 to children\.\n'
             b'\[dumb-init\] Child exited with status 0\. Goodbye\.\n$'


### PR DESCRIPTION
This fixes #58 by processing signals synchronously. It simplifies our code because we don't need to worry about all the special cases that exist for asynchronous signal handlers (there are [lots of them](https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=3903)).

There shouldn't be any behavior changes here. All existing tests (which are pretty comprehensive) passed, with the exception of the one that tests debug output (since we now report when we get `SIGCHLD` as well if running in verbose/debug mode).

This also drops the use of `signal` which @kpengboy pointed out.