### PR TITLE
dumb-init is not a pure python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,25 @@ from setuptools import setup
 from setuptools.command.install import install as orig_install
 
 
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class bdist_wheel(_bdist_wheel):
+
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            # Mark us as not a pure python package
+            self.root_is_pure = False
+
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            # We don't contain any python source
+            python, abi = 'py2.py3', 'none'
+            return python, abi, plat
+except ImportError:
+    bdist_wheel = None
+
+
 class ExeDistribution(Distribution):
     c_executables = ()
 
@@ -99,6 +118,7 @@ setup(
         ),
     ],
     cmdclass={
+        'bdist_wheel': bdist_wheel,
         'build': build,
         'build_cexe': build_cexe,
         'install': install,


### PR DESCRIPTION
Before:

```
$ rm -f *.whl && pip wheel . >& /dev/null && ls *.whl
dumb_init-1.0.2-py2-none-any.whl
```

After:

```
$ rm -f *.whl && pip wheel . >& /dev/null && ls *.whl
dumb_init-1.0.2-py2.py3-none-linux_x86_64.whl
```