### PR TITLE
Add '--signal' option to replace SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ completely transparent; you can even string multiple together (like `dumb-init
 dumb-init echo 'oh, hi'`).
 
 
+### Signal rewriting
+
+dumb-init allows rewriting incoming signals before proxying them. This is
+useful in cases where you have a Docker supervisor (like Mesos or Kubernates)
+which always sends a standard signal (e.g. SIGTERM). Some apps require a
+different stop signal in order to do graceful cleanup.
+
+For example, to rewrite the signal SIGTERM (number 15) to SIGQUIT (number 3),
+just add `--rewrite 15:3` on the command line.
+
+One caveat with this feature: for job control signals (SIGTSTP, SIGTTIN,
+SIGTTOU), dumb-init will always suspend itself after receiving the signal, even
+if you rewrite it to something else. Additionally, if in setsid mode, dumb-init
+will always forward SIGSTOP instead, since the original signals have no effect
+unless the child has handlers for them.
+
+
 ## Installing inside Docker containers
 
 You have a few options for using `dumb-init`:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -40,6 +40,7 @@ def test_help_message(flag, both_debug_modes, both_setsid_modes, current_version
         b'   -c, --single-child   Run in single-child mode.\n'
         b'                        In this mode, signals are only proxied to the\n'
         b'                        direct child and not any of its descendants.\n'
+        b'   -r, --rewrite s:r    Rewrite signum s to signum r before proxying.\n'
         b'   -v, --verbose        Print debugging information to stderr.\n'
         b'   -h, --help           Print this help message and exit.\n'
         b'   -V, --version        Print the current version and exit.\n'

--- a/tests/proxies_signals_test.py
+++ b/tests/proxies_signals_test.py
@@ -2,25 +2,84 @@ import os
 import re
 import signal
 import sys
+from contextlib import contextmanager
+from itertools import chain
 from subprocess import PIPE
 from subprocess import Popen
+
+import pytest
 
 from tests.lib.testing import NORMAL_SIGNALS
 from tests.lib.testing import pid_tree
 
 
-def test_proxies_signals(both_debug_modes, both_setsid_modes):
-    """Ensure dumb-init proxies regular signals to its child."""
+@contextmanager
+def _print_signals(args=()):
+    """Start print_signals and return dumb-init process."""
     proc = Popen(
-        ('dumb-init', sys.executable, '-m', 'tests.lib.print_signals'),
+        (
+            ('dumb-init',) +
+            tuple(args) +
+            (sys.executable, '-m', 'tests.lib.print_signals')
+        ),
         stdout=PIPE,
     )
-
     assert re.match(b'^ready \(pid: (?:[0-9]+)\)\n$', proc.stdout.readline())
 
-    for signum in NORMAL_SIGNALS:
-        proc.send_signal(signum)
-        assert proc.stdout.readline() == '{0}\n'.format(signum).encode('ascii')
+    yield proc
 
     for pid in pid_tree(proc.pid):
         os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_proxies_signals():
+    """Ensure dumb-init proxies regular signals to its child."""
+    with _print_signals() as proc:
+        for signum in NORMAL_SIGNALS:
+            proc.send_signal(signum)
+            assert proc.stdout.readline() == '{0}\n'.format(signum).encode('ascii')
+
+
+def _rewrite_map_to_args(rewrite_map):
+    return chain.from_iterable(
+        ('-r', '{0}:{1}'.format(src, dst)) for src, dst in rewrite_map.items()
+    )
+
+
+@pytest.mark.parametrize('rewrite_map,sequence,expected', [
+    (
+        {},
+        [signal.SIGTERM, signal.SIGQUIT, signal.SIGCONT, signal.SIGINT],
+        [signal.SIGTERM, signal.SIGQUIT, signal.SIGCONT, signal.SIGINT],
+    ),
+
+    (
+        {signal.SIGTERM: signal.SIGINT},
+        [signal.SIGTERM, signal.SIGQUIT, signal.SIGCONT, signal.SIGINT],
+        [signal.SIGINT, signal.SIGQUIT, signal.SIGCONT, signal.SIGINT],
+    ),
+
+    (
+        {
+            signal.SIGTERM: signal.SIGINT,
+            signal.SIGINT: signal.SIGTERM,
+            signal.SIGQUIT: signal.SIGQUIT,
+        },
+        [signal.SIGTERM, signal.SIGQUIT, signal.SIGCONT, signal.SIGINT],
+        [signal.SIGINT, signal.SIGQUIT, signal.SIGCONT, signal.SIGTERM],
+    ),
+
+    (
+        {1: 31, 31: 1},
+        [1, 31],
+        [31, 1],
+    ),
+])
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_proxies_signals_with_rewrite(rewrite_map, sequence, expected):
+    """Ensure dumb-init can rewrite signals."""
+    with _print_signals(_rewrite_map_to_args(rewrite_map)) as proc:
+        for send, expect_receive in zip(sequence, expected):
+            proc.send_signal(send)
+            assert proc.stdout.readline() == '{0}\n'.format(expect_receive).encode('ascii')


### PR DESCRIPTION
Many servers respond to other signals than SIGTERM for their "graceful shutdown" option, such as Unicorn which requires SIGQUIT to wait on outstanding connections. The `docker stop` command sends the SIGTERM signal to the container, and provides no option for modifying this behavior. The `docker kill` command has an `-s` option which allows one to modify the signal sent to the container, but orchestration frameworks such as Mesos don't provide a way to use this functionality.

This commit adds the `-s/--signal` option to dumb-init, which provides a replacement signal for SIGTERM. For instance, running dumb-init like so:

```
dumb-init -s 3 <command>
```

Will send SIGQUIT (3) to the <command> process it spawns when dumb-init receives a SIGTERM. This allows Docker image writers the freedom to specify how the `docker stop` SIGTERM will behave in their containers.