### PR TITLE
Fix segfault on invalid arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Chris Kuehl <ckuehl@yelp.com>
 

--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,10 @@ Build-Depends:
  help2man,
  musl-tools,
 ## Tests:
+ procps,
  python,
- python-pytest,
  python-mock,
+ python-pytest,
 Standards-Version: 3.9.7
 Homepage: https://github.com/Yelp/dumb-init
 Vcs-Browser: https://github.com/Yelp/dumb-init

--- a/dumb-init.c
+++ b/dumb-init.c
@@ -173,6 +173,7 @@ char **parse_command(int argc, char *argv[]) {
         {"rewrite",      required_argument, NULL, 'r'},
         {"verbose",      no_argument,       NULL, 'v'},
         {"version",      no_argument,       NULL, 'V'},
+        {NULL,                     0,       NULL,   0},
     };
     while ((opt = getopt_long(argc, argv, "+hvVcr:", long_options, NULL)) != -1) {
         switch (opt) {

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -21,6 +21,14 @@ def test_no_arguments_prints_usage(both_debug_modes, both_setsid_modes):
     )
 
 
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_exits_invalid_with_invalid_args():
+    proc = Popen(('dumb-init', '--yolo', '/bin/true'), stderr=PIPE)
+    _, stderr = proc.communicate()
+    assert proc.returncode == 1
+    assert stderr == b"dumb-init: unrecognized option '--yolo'\n"
+
+
 @pytest.mark.parametrize('flag', ['-h', '--help'])
 def test_help_message(flag, both_debug_modes, both_setsid_modes, current_version):
     """dumb-init should say something useful when called with the help flag,

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -26,7 +26,10 @@ def test_exits_invalid_with_invalid_args():
     proc = Popen(('dumb-init', '--yolo', '/bin/true'), stderr=PIPE)
     _, stderr = proc.communicate()
     assert proc.returncode == 1
-    assert stderr == b"dumb-init: unrecognized option '--yolo'\n"
+    assert stderr in (
+        b"dumb-init: unrecognized option '--yolo'\n",  # glibc
+        b'dumb-init: unrecognized option: yolo\n',  # musl
+    )
 
 
 @pytest.mark.parametrize('flag', ['-h', '--help'])


### PR DESCRIPTION
Not particularly dangerous, but a bit embarrassing:

```
ckuehl@sodium:~$ dumb-init --hello
zsh: segmentation fault  dumb-init --hello
```