### PR TITLE
Make tests a bit less leaky

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,6 +1,7 @@
-*.log
-*.substvars
-files
-substvars
-dumb-init/
-dumb-init.1
+/*.log
+/*.substvars
+/files
+/substvars
+/dumb-init/
+/dumb-init.1
+/debhelper-build-stamp

--- a/debian/rules
+++ b/debian/rules
@@ -31,5 +31,4 @@ override_dh_builddeb:
 override_dh_auto_test:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
-	PATH=.:$$PATH py.test tests/
-	ps aux
+	PATH=.:$$PATH timeout --signal=KILL 60 py.test -vv tests/


### PR DESCRIPTION
We have a problem on our Jenkins CI where sometimes the `builddeb-docker` stage hangs indefinitely and leaves processes running taking up CPU:

```
21:51:21 make[1]: Entering directory '/mnt'
21:51:21 find . -name '*.pyc' -delete
21:51:21 find . -name '__pycache__' -delete
21:51:21 PATH=.:$PATH py.test tests/
21:51:21 ============================= test session starts ==============================
21:51:21 platform linux2 -- Python 2.7.12rc1, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
21:51:21 rootdir: /mnt, inifile: pytest.ini
21:51:21 collected 173 items
21:51:21 
23:50:07 tests/child_processes_test.py .............Build timed out (after 120 minutes). Marking the build as aborted.
```

We don't know exactly what tests are being failed to investigate further, so let's solve the immediate problem by adding a timeout (should prevent leaking containers) and make py.test verbose so we can see what test is failing to try to investigate further.