### PR TITLE
Be more generous with sleeps in tests, add more test output on fail

### DIFF
--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -2,6 +2,7 @@ import os
 import re
 import signal
 import sys
+import time
 from contextlib import contextmanager
 from subprocess import PIPE
 from subprocess import Popen
@@ -75,3 +76,19 @@ def process_state(pid):
     status = LocalPath('/proc').join(str(pid), 'status').read()
     m = re.search('^State:\s+[A-Z] \(([a-z]+)\)$', status, re.MULTILINE)
     return m.group(1)
+
+
+def sleep_until(fn, timeout=1.5):
+    """Sleep until fn succeeds, or we time out."""
+    interval = 0.01
+    so_far = 0
+    while True:
+        try:
+            fn()
+        except:
+            if so_far >= timeout:
+                raise
+        else:
+            break
+        time.sleep(interval)
+        so_far += interval

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -92,7 +92,7 @@ def test_verbose(flag):
             b'\[dumb-init\] Child exited with status 0\. Goodbye\.\n$'
         ),
         stderr,
-    )
+    ), stderr
 
 
 @pytest.mark.parametrize('flag1', ['-v', '--verbose'])

--- a/tests/shell_background_test.py
+++ b/tests/shell_background_test.py
@@ -1,11 +1,11 @@
 import os
-import time
 from signal import SIGCONT
 
 import pytest
 
 from testing import print_signals
 from testing import process_state
+from testing import sleep_until
 from testing import SUSPEND_SIGNALS
 
 
@@ -23,17 +23,10 @@ def test_shell_background_support_setsid():
             # both should now suspend
             proc.send_signal(signum)
 
-            for _ in range(1000):
-                time.sleep(0.001)
-                try:
-                    assert process_state(proc.pid) == 'stopped'
-                    assert process_state(pid) == 'stopped'
-                except AssertionError:
-                    pass
-                else:
-                    break
-            else:
-                raise RuntimeError('Timed out waiting for processes to stop.')
+            def assert_both_stopped():
+                assert process_state(proc.pid) == process_state(pid) == 'stopped'
+
+            sleep_until(assert_both_stopped)
 
             # and then both wake up again
             proc.send_signal(SIGCONT)


### PR DESCRIPTION
Some tests are still rather flaky, especially on CI. Hopefully this can help with making some of the time-dependent ones less flaky, or at least produce better output when it fails so we can further investigate that.