### PR TITLE
Fixes for FreeBSD kernel

### DIFF
--- a/tests/tty_test.py
+++ b/tests/tty_test.py
@@ -29,7 +29,7 @@ def readall(fd):
                 return result
             else:
                 raise
-        if chunk == '':
+        if chunk == b'':
             return result
         else:
             result += chunk


### PR DESCRIPTION
This gets dumb-init tests passing on Debian jessie's kfreebsd amd64 port.

```
root@debian:~/dumb-init# tox
GLOB sdist-make: /root/dumb-init/setup.py
py26 create: /root/dumb-init/.tox/py26
ERROR: InterpreterNotFound: python2.6
py27 create: /root/dumb-init/.tox/py27
py27 installdeps: -r/root/dumb-init/requirements-dev.txt
py27 inst: /root/dumb-init/.tox/dist/dumb-init-1.1.2.zip
py27 runtests: PYTHONHASHSEED='1783920667'
py27 runtests: commands[0] | python -m pytest
=============================================== test session starts ================================================
platform gnukfreebsd9 -- Python 2.7.9, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /root/dumb-init, inifile: pytest.ini
plugins: timeout-1.0.0
collected 173 items

tests/child_processes_test.py ........................
tests/cli_test.py ......................................................................
tests/exit_status_test.py ................................................
tests/proxies_signals_test.py ..........................
tests/shell_background_test.py ....
tests/tty_test.py .

============================================ 173 passed in 8.77 seconds ============================================
py27 runtests: commands[1] | pre-commit run --all-files
autopep8 wrapper.............................................................................................Passed
Check for added large files..................................................................................Passed
Check docstring is first.....................................................................................Passed
Check for merge conflicts....................................................................................Passed
Check Yaml...................................................................................................Passed
Debug Statements (Python)....................................................................................Passed
Detect Private Key...........................................................................................Passed
Fix double quoted strings....................................................................................Passed
Fix End of Files.............................................................................................Passed
Flake8.......................................................................................................Passed
Tests should end in _test.py.................................................................................Passed
Fix requirements.txt.........................................................................................Passed
Trim Trailing Whitespace.....................................................................................Passed
Reorder python imports.......................................................................................Passed
Tabs remover.................................................................................................Passed
py34 create: /root/dumb-init/.tox/py34
py34 installdeps: -r/root/dumb-init/requirements-dev.txt
py34 inst: /root/dumb-init/.tox/dist/dumb-init-1.1.2.zip
py34 runtests: PYTHONHASHSEED='1783920667'
py34 runtests: commands[0] | python -m pytest
=============================================== test session starts ================================================
platform gnukfreebsd9 -- Python 3.4.2, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /root/dumb-init, inifile: pytest.ini
plugins: timeout-1.0.0
collected 173 items

tests/child_processes_test.py ........................
tests/cli_test.py ......................................................................
tests/exit_status_test.py ................................................
tests/proxies_signals_test.py ..........................
tests/shell_background_test.py ....
tests/tty_test.py .

=========================================== 173 passed in 10.70 seconds ============================================
py34 runtests: commands[1] | pre-commit run --all-files
autopep8 wrapper.............................................................................................Passed
Check for added large files..................................................................................Passed
Check docstring is first.....................................................................................Passed
Check for merge conflicts....................................................................................Passed
Check Yaml...................................................................................................Passed
Debug Statements (Python)....................................................................................Passed
Detect Private Key...........................................................................................Passed
Fix double quoted strings....................................................................................Passed
Fix End of Files.............................................................................................Passed
Flake8.......................................................................................................Passed
Tests should end in _test.py.................................................................................Passed
Fix requirements.txt.........................................................................................Passed
Trim Trailing Whitespace.....................................................................................Passed
Reorder python imports.......................................................................................Passed
Tabs remover.................................................................................................Passed
_____________________________________________________ summary ______________________________________________________
ERROR:   py26: InterpreterNotFound: python2.6
  py27: commands succeeded
  py34: commands succeeded
```