### PR TITLE
Loosen a /proc assertion

### DIFF
--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -53,7 +53,7 @@ def child_pids(pid):
         stat = p.join('stat')
         if stat.isfile():
             stat = stat.open().read()
-            m = re.match('^\d+ \([^\)]+\) [a-zA-Z] (\d+) ', stat)
+            m = re.match('^\d+ \(.+?\) [a-zA-Z] (\d+) ', stat)
             assert m, stat
             ppid = int(m.group(1))
             if ppid == pid:


### PR DESCRIPTION
`/proc/<pid>/stat` looks like this:

```
1 (systemd) S 0 1 1 0 -1 4194560 23690 2483705 68 836 153 221 50935 30286 [...lots more stuff...]
```

Previously our assertion failed to match the `(systemd)` part for some processes, e.g.:

```
    def child_pids(pid):
        """Return a list of direct child PIDs for the given PID."""
        children = set()
        for p in LocalPath('/proc').listdir():
            stat = p.join('stat')
            if stat.isfile():
                stat = stat.open().read()
                m = re.match('^\d+ \([^\)]+\) [a-zA-Z] (\d+) ', stat)
>               assert m, stat
E               AssertionError: 2127 ((sd-pam)) S 2125 2125 2125 0 -1 1077936448 23 0 0 0 0 0 0 0 20 0 1 0 3443 80334848 476 18446744073709551615 1 1 0 0 0 0 0 4096 0 0 0 0 17 3 0 0 0 0 0 0 0 0 0 0 0 0 0

testing/__init__.py:57: AssertionError
```

This seemed to be happening with systemd as init, but probably in other cases too.

Loosening the assertion seems reasonable since we can't use `scanf` (the suggested way) to parse this. Keep in mind the filename can also contain spaces.