### PR TITLE
Fix race reading /proc in tests

### DIFF
--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -50,14 +50,17 @@ def child_pids(pid):
     """Return a list of direct child PIDs for the given PID."""
     children = set()
     for p in LocalPath('/proc').listdir():
-        stat = p.join('stat')
-        if stat.isfile():
-            stat = stat.open().read()
+        try:
+            stat = open(p.join('stat').strpath).read()
             m = re.match('^\d+ \(.+?\) [a-zA-Z] (\d+) ', stat)
             assert m, stat
             ppid = int(m.group(1))
             if ppid == pid:
                 children.add(int(p.basename))
+        except IOError:
+            # Happens when the process exits after listing it, or between
+            # opening stat and reading it.
+            pass
     return children
 
 


### PR DESCRIPTION
There's a race in the tests where a process exits after we open `/proc/<pid>/stat`:

```
13:25:20.891     def child_pids(pid):
13:25:20.891         """Return a list of direct child PIDs for the given PID."""
13:25:20.891         children = set()
13:25:20.891         for p in LocalPath('/proc').listdir():
13:25:20.892             stat = p.join('stat')
13:25:20.892             if stat.isfile():
13:25:20.892 >               stat = stat.open().read()
13:25:20.892 E               ProcessLookupError: [Errno 3] No such process
```

This particular one is `open => process exits => read`, but there's also a problem of us opening after it no longer exists.

It's safe to ignore these.