### PR TITLE
Fix exit_status_test on Fedora

### DIFF
--- a/tests/exit_status_test.py
+++ b/tests/exit_status_test.py
@@ -1,3 +1,4 @@
+import distutils.spawn
 import signal
 from subprocess import Popen
 
@@ -26,6 +27,11 @@ def test_exit_status_terminated_by_signal(signal):
     """dumb-init should exit with status 128 + signal when the child process is
     terminated by a signal.
     """
-    proc = Popen(('dumb-init', 'sh', '-c', 'kill -{0} $$'.format(signal)))
+    # We need to make sure not to use the built-in kill (if on Bash):
+    # https://github.com/Yelp/dumb-init/issues/115
+    proc = Popen(('dumb-init', 'sh', '-c', '{0} -{1} $$'.format(
+        distutils.spawn.find_executable('kill'),
+        signal,
+    )))
     proc.wait()
     assert proc.returncode == 128 + signal

--- a/tests/exit_status_test.py
+++ b/tests/exit_status_test.py
@@ -1,5 +1,5 @@
-import distutils.spawn
 import signal
+import sys
 from subprocess import Popen
 
 import pytest
@@ -18,7 +18,7 @@ def test_exit_status_regular_exit(exit_status):
 
 @pytest.mark.parametrize('signal', [
     signal.SIGTERM,
-    signal.SIGINT,
+    signal.SIGHUP,
     signal.SIGQUIT,
     signal.SIGKILL,
 ])
@@ -27,10 +27,9 @@ def test_exit_status_terminated_by_signal(signal):
     """dumb-init should exit with status 128 + signal when the child process is
     terminated by a signal.
     """
-    # We need to make sure not to use the built-in kill (if on Bash):
+    # We use Python because sh is "dash" on Debian and "bash" on others.
     # https://github.com/Yelp/dumb-init/issues/115
-    proc = Popen(('dumb-init', 'sh', '-c', '{0} -{1} $$'.format(
-        distutils.spawn.find_executable('kill'),
+    proc = Popen(('dumb-init', sys.executable, '-c', 'import os; os.kill(os.getpid(), {0})'.format(
         signal,
     )))
     proc.wait()


### PR DESCRIPTION
Fixes #115 

bash has some weird behavior compared to dash:

```
ckuehl@sodium:~$ dumb-init bash -c 'kill -3 $$'; echo $?
0
ckuehl@sodium:~$ dumb-init dash -c 'kill -3 $$'; echo $?
131
```

If we use `/bin/kill`, then it works:

```
ckuehl@sodium:~$ dumb-init bash -c '/bin/kill -3 $$'; echo $?
131
```

Super weird! Probably easier to just use Python.