### PR TITLE
Set language_version: python3.5 on pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,38 @@
     sha: 003e43251aea1da33f2072f2365ec8b9ceaae070
     hooks:
     -   id: autopep8-wrapper
+        language_version: python3.5
     -   id: check-added-large-files
+        language_version: python3.5
     -   id: check-docstring-first
+        language_version: python3.5
     -   id: check-merge-conflict
+        language_version: python3.5
     -   id: check-yaml
+        language_version: python3.5
     -   id: debug-statements
+        language_version: python3.5
     -   id: detect-private-key
+        language_version: python3.5
     -   id: double-quote-string-fixer
+        language_version: python3.5
     -   id: end-of-file-fixer
+        language_version: python3.5
     -   id: flake8
+        language_version: python3.5
     -   id: name-tests-test
+        language_version: python3.5
     -   id: requirements-txt-fixer
+        language_version: python3.5
     -   id: trailing-whitespace
+        language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
     sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
     hooks:
     -   id: reorder-python-imports
+        language_version: python3.5
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
     sha: 181a63c511691da58116fa19a7241956018660bc
     hooks:
     -   id: remove-tabs
+        language_version: python3.5


### PR DESCRIPTION
If you don't specify `language_version` on pre-commit hooks, it uses the "default" language version. Usually this is safe because it's whatever the hook first run as (usually python2.7 or python3.x, something sane), but it can happen that the hook first ran with python2.6, and then you get errors like this:

```
21:49:26 /nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/options/config.py:56: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
21:49:26   found_files = config.read(files)
21:49:26 Traceback (most recent call last):
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/bin/flake8", line 11, in <module>
21:49:26     sys.exit(main())
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/main/cli.py", line 16, in main
21:49:26     app.run(argv)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/main/application.py", line 316, in run
21:49:26     self._run(argv)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/main/application.py", line 300, in _run
21:49:26     self.run_checks()
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/main/application.py", line 237, in run_checks
21:49:26     self.file_checker_manager.start(files)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/checker.py", line 364, in start
21:49:26     self.make_checkers(paths)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/checker.py", line 272, in make_checkers
21:49:26     checks = self.checks.to_dictionary()
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/plugins/manager.py", line 450, in to_dictionary
21:49:26     plugin.to_dictionary() for plugin in self.ast_plugins
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/plugins/manager.py", line 488, in ast_plugins
21:49:26     plugins = list(self.checks_expecting('tree'))
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/plugins/manager.py", line 443, in checks_expecting
21:49:26     if argument_name == plugin.parameter_names[0]:
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/plugins/manager.py", line 95, in parameter_names
21:49:26     self._parameter_names = list(self.parameters)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/plugins/manager.py", line 88, in parameters
21:49:26     self._parameters = utils.parameters_for(self)
21:49:26   File "/nail/home/jenkins/.pre-commit/repoiFq82j/py_env-default/lib/python2.6/site-packages/flake8/utils.py", line 297, in parameters_for
21:49:26     parameters = collections.OrderedDict([
21:49:26 AttributeError: 'module' object has no attribute 'OrderedDict'
```

(This only started happening recently because flake8 3.0 dropped support for python2.6.)