### PR TITLE
Only run pre-commit on python3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ docker-image:
 .PHONY: test
 test:
 	tox
+	tox -e pre-commit
 
 .PHONY: install-hooks
 install-hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ deps = -r{toxinidir}/requirements-dev.txt
 passenv = HOME SSH_AUTH_SOCK USER
 commands =
     python -m pytest
-    pre-commit run --all-files
 
 [testenv:pre-commit]
-commands = pre-commit {posargs}
+basepython = /usr/bin/python3.5
+commands = pre-commit {posargs:run --all-files}
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
pre-commit dropped python2.6 support. Let's just only run these with python3.5 anyway (we already added `language_version: python3.5` to all the Python hooks).