### PR TITLE
Fix the binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ entrypoint. An "entrypoint" is a partial command that gets prepended to your
 `CMD` instruction, making it a great fit for dumb-init:
 
 ```Dockerfile
-# Runs "/usr/bin/dumb-init -- /my/script --with --args"
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+# Runs "/usr/local/bin/dumb-init -- /my/script --with --args"
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/my/script", "--with", "--args"]
 ```
 


### PR DESCRIPTION
In "Option 3: Downloading the binary directly", the commands save the binary as `/usr/local/bin/dumb-init`, but when executing in ENTRYPOINT the path was `/usr/bin/`.