### PR TITLE
Add lintian to the build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ MAINTAINER Chris Kuehl <ckuehl@yelp.com>
 # debian/control instead.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential devscripts equivs && \
-    rm -rf /var/lib/apt/lists/* && apt-get clean
+        build-essential \
+        devscripts \
+        equivs \
+        lintian \
+    && rm -rf /var/lib/apt/lists/* && apt-get clean
 WORKDIR /mnt
 
 ENTRYPOINT apt-get update && \

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,0 +1,1 @@
+dumb-init binary: statically-linked-binary


### PR DESCRIPTION
This fixes bitrot from a change made to devscripts (landed in Debian testing today) which adds a stricter dependency on lintian: https://packages.qa.debian.org/d/devscripts/news/20161202T163908Z.html

Same bug and fix as https://github.com/Yelp/aactivator/pull/15