### PR TITLE
Use less flaky mirrors, add python3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,38 +2,38 @@
     sha: 003e43251aea1da33f2072f2365ec8b9ceaae070
     hooks:
     -   id: autopep8-wrapper
-        language_version: python3.5
+        language_version: python3.6
     -   id: check-added-large-files
-        language_version: python3.5
+        language_version: python3.6
     -   id: check-docstring-first
-        language_version: python3.5
+        language_version: python3.6
     -   id: check-merge-conflict
-        language_version: python3.5
+        language_version: python3.6
     -   id: check-yaml
-        language_version: python3.5
+        language_version: python3.6
     -   id: debug-statements
-        language_version: python3.5
+        language_version: python3.6
     -   id: detect-private-key
-        language_version: python3.5
+        language_version: python3.6
     -   id: double-quote-string-fixer
-        language_version: python3.5
+        language_version: python3.6
     -   id: end-of-file-fixer
-        language_version: python3.5
+        language_version: python3.6
     -   id: flake8
-        language_version: python3.5
+        language_version: python3.6
     -   id: name-tests-test
-        language_version: python3.5
+        language_version: python3.6
     -   id: requirements-txt-fixer
-        language_version: python3.5
+        language_version: python3.6
     -   id: trailing-whitespace
-        language_version: python3.5
+        language_version: python3.6
 -   repo: https://github.com/asottile/reorder_python_imports.git
     sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
     hooks:
     -   id: reorder-python-imports
-        language_version: python3.5
+        language_version: python3.6
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
     sha: 181a63c511691da58116fa19a7241956018660bc
     hooks:
     -   id: remove-tabs
-        language_version: python3.5
+        language_version: python3.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM debian:stretch
 
 MAINTAINER Chris Kuehl <ckuehl@yelp.com>
 
+# The default mirrors are too flaky to run reliably in CI.
+RUN sed -E \
+    '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+    -i /etc/apt/sources.list
+
 # Install the bare minimum dependencies necessary for working with Debian
 # packages. Build dependencies should be added under "Build-Depends" inside
 # debian/control instead.

--- a/ci/docker
+++ b/ci/docker
@@ -2,6 +2,11 @@ if grep -qE '\<lucid\>' /etc/apt/sources.list; then
     # lucid was archived, breaking the base image
     # https://github.com/docker-library/official-images/issues/1902
     sed -i 's/archive\.ubuntu\.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+else
+    # The default mirrors are too flaky to run reliably in CI.
+    sed -E \
+        '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+        -i /etc/apt/sources.list
 fi
 
 apt-get update

--- a/ci/docker-tox
+++ b/ci/docker-tox
@@ -3,15 +3,21 @@ set -o pipefail
 
 . /mnt/ci/docker
 
+# The default mirrors are too flaky to run reliably in CI.
+sed -E \
+    '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+    -i /etc/apt/sources.list
+
 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0x5BB92C09DB82666C
 echo 'deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu xenial main' >> /etc/apt/sources.list
+
 apt-get update
 apt-get install -y --no-install-recommends \
     git \
     python2.6-dev \
     python2.7-dev \
-    python3.4-dev \
-    python3.5-dev
+    python3.5-dev \
+    python3.6-dev
 
 # We cannot use the Ubuntu versions of tox or virtualenv:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=754248

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35
+envlist = py26,py27,py35,py36
 
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
The default debian mirrors (deb. or httpredir.) are just too flaky and fail on CI frequently. This generates noise which we can't really do anything about, except to use different mirrors :(