### PR TITLE
Add a gcov tox environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-dumb-init
-dist/
 *.deb
 *.egg-info
-.tox
-build/
-__pycache__/
+*.gc*
+*.o
 *.py[cod]
 .cache
+.tox
+__pycache__/
+build/
+dist/
+dumb-init

--- a/ci/docker-tox
+++ b/ci/docker-tox
@@ -9,14 +9,12 @@ sed -E \
     -i /etc/apt/sources.list
 
 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0x5BB92C09DB82666C
-echo 'deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu xenial main' >> /etc/apt/sources.list
+echo 'deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main' >> /etc/apt/sources.list
 
 apt-get update
 apt-get install -y --no-install-recommends \
     git \
-    python2.6-dev \
     python2.7-dev \
-    python3.5-dev \
     python3.6-dev
 
 # We cannot use the Ubuntu versions of tox or virtualenv:

--- a/ci/gcov-build
+++ b/ci/gcov-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+envbindir="$1"
+cc -c dumb-init.c -o dumb-init.o -g --coverage
+cc dumb-init.o -o "${envbindir}/dumb-init" -g --coverage

--- a/ci/gcov-report
+++ b/ci/gcov-report
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+gcov -f dumb-init.c
+grep '#####' dumb-init.c.gcov | cut -d':' -f2 | xargs echo "Missing:"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,18 @@
 [tox]
-envlist = py26,py27,py35,py36
+envlist = py27,py36,gcov
 
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt
-passenv = HOME SSH_AUTH_SOCK USER
+passenv = SSH_AUTH_SOCK
 commands =
     python -m pytest
+
+[testenv:gcov]
+skip_install = True
+commands =
+    {toxinidir}/ci/gcov-build {envbindir}
+    {[testenv]commands}
+    {toxinidir}/ci/gcov-report
 
 [testenv:pre-commit]
 basepython = /usr/bin/python3.6


### PR DESCRIPTION
I also:
- updated to use the new deadsnakes ppa
- dropped py26 / py35 -- they're not actually adding useful coverage for `dumb-init`'s sake

I initially tried doing this through setup.py, but the gcov metadata files (`.gcda`, `.gcno`) were getting lost in the setuptools build directory \*poof\*.

Current output:

```
$ tox -e gcov
GLOB sdist-make: /home/asottile/workspace/dumb-init/setup.py
gcov installed: aspy.yaml==1.0.0,cached-property==1.3.1,identify==1.0.6,mock==2.0.0,nodeenv==1.2.0,pbr==3.1.1,pre-commit==1.3.0,py==1.4.34,pytest==3.2.3,pytest-timeout==1.2.0,PyYAML==3.12,six==1.11.0,virtualenv==15.1.0
gcov runtests: PYTHONHASHSEED='555642006'
gcov runtests: commands[0] | /home/asottile/workspace/dumb-init/ci/gcov-build /home/asottile/workspace/dumb-init/.tox/gcov/bin
gcov runtests: commands[1] | python -m pytest
============================= test session starts ==============================
platform linux -- Python 3.6.3, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/asottile/workspace/dumb-init, inifile: pytest.ini
plugins: timeout-1.2.0
timeout: 5.0s method: signal
collected 177 items                                                             

tests/child_processes_test.py ........................
tests/cli_test.py ......................................................................
tests/exit_status_test.py ................................................
tests/proxies_signals_test.py ..........................
tests/shell_background_test.py ....
tests/tty_test.py .....

========================== 177 passed in 9.11 seconds ==========================
gcov runtests: commands[2] | /home/asottile/workspace/dumb-init/ci/gcov-report
Function 'main'
Lines executed:86.21% of 29

Function 'dummy'
Lines executed:0.00% of 1

Function 'parse_command'
Lines executed:100.00% of 31

Function 'set_rewrite_to_sigstop_if_not_defined'
Lines executed:100.00% of 4

Function 'parse_rewrite_signum'
Lines executed:100.00% of 8

Function 'print_rewrite_signum_help'
Lines executed:100.00% of 3

Function 'print_help'
Lines executed:100.00% of 3

Function 'handle_signal'
Lines executed:100.00% of 19

Function 'forward_signal'
Lines executed:100.00% of 7

Function 'translate_signal'
Lines executed:87.50% of 8

File 'dumb-init.c'
Lines executed:94.69% of 113
Creating 'dumb-init.c.gcov'

Missing: 48 242 265 266 272 277
___________________________________ summary ____________________________________
  gcov: commands succeeded
  congratulations :)
```