### PR TITLE
Fix bitrot (remove pip upgrade)

### DIFF
--- a/ci/docker
+++ b/ci/docker
@@ -12,10 +12,6 @@ apt-get install -y --no-install-recommends \
     python-pip \
     python-setuptools
 
-pip install --upgrade pip
-hash -r
-pip --version
-
 cp -r /mnt/ /test
 cd /test
 

--- a/ci/docker-deb-test
+++ b/ci/docker-deb-test
@@ -4,7 +4,6 @@ set -o pipefail
 . /mnt/ci/docker
 
 dpkg -i dist/*.deb
-pip install --upgrade setuptools distribute
 pip install -r requirements-dev.txt
 py.test tests/
 

--- a/ci/docker-python-test
+++ b/ci/docker-python-test
@@ -5,7 +5,6 @@ set -o pipefail
 
 python setup.py clean
 python setup.py sdist
-pip install --upgrade setuptools distribute
 pip install -vv dist/*.tar.gz
 pip install -r requirements-dev.txt
 py.test tests/


### PR DESCRIPTION
We don't need this anymore now that we don't build on lucid, and this fixes a current build error.