### PR TITLE
Upload artifacts as part of the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: c
 services:
     - docker
 
+addons:
+    artifacts:
+        target_paths:
+            - /dumb-init/${TRAVIS_BUILD_NUMBER}/${ITEST_TARGET}
+        paths:
+            - $(find dist -type f | tr "\n" ':')
+
 env:
     matrix:
         - ITEST_TARGET=itest_trusty
@@ -13,3 +20,9 @@ env:
 
 script:
    - make "$ITEST_TARGET"
+
+after_script:
+   - if [ -n "${ARTIFACTS_SECRET:-}" ]; then
+         echo 'Build artifacts are available at:';
+         find dist -type f | xargs --replace echo "* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/${TRAVIS_BUILD_NUMBER}/${ITEST_TARGET}/{}";
+     fi

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CFLAGS=-std=gnu99 -static -s -Wall -Werror -O3
 TEST_PACKAGE_DEPS := build-essential python python-pip procps python-dev python-setuptools
 
 DOCKER_RUN_TEST := docker run -v $(PWD):/mnt:ro
+VERSION = $(shell cat VERSION)
 
 .PHONY: build
 build: VERSION.h
@@ -24,11 +25,6 @@ clean-tox:
 
 .PHONY: release
 release: python-dists builddeb-docker
-	$(eval VERSION := $(shell cat VERSION))
-	# extract the built binary from the Debian package
-	dpkg-deb --fsys-tarfile dist/dumb-init_$(VERSION)_amd64.deb | \
-		tar -C dist --strip=3 -xvf - ./usr/bin/dumb-init
-	mv dist/dumb-init dist/dumb-init_$(VERSION)_amd64
 	cd dist && \
 		sha256sum --binary dumb-init_$(VERSION)_amd64.deb dumb-init_$(VERSION)_amd64 \
 		> sha256sums
@@ -50,6 +46,10 @@ builddeb:
 	debuild --set-envvar=CC=musl-gcc -us -uc -b
 	mkdir -p dist
 	mv ../dumb-init_*.deb dist/
+	# Extract the built binary from the Debian package
+	dpkg-deb --fsys-tarfile dist/dumb-init_$(VERSION)_$(shell dpkg --print-architecture).deb | \
+		tar -C dist --strip=3 -xvf - ./usr/bin/dumb-init
+	mv dist/dumb-init dist/dumb-init_$(VERSION)_$(shell dpkg --print-architecture)
 
 .PHONY: builddeb-docker
 builddeb-docker: docker-image


### PR DESCRIPTION
This is a step toward #161: once we can get artifacts out of the Travis build, we can start releasing them.

* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_bionic/dist/dumb-init_1.2.1_amd64
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_bionic/dist/dumb-init_1.2.1_amd64.deb
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_jessie/dist/dumb-init_1.2.1_amd64
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_jessie/dist/dumb-init_1.2.1_amd64.deb
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_stretch/dist/dumb-init_1.2.1_amd64
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_stretch/dist/dumb-init_1.2.1_amd64.deb
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_trusty/dist/dumb-init_1.2.1_amd64
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_trusty/dist/dumb-init_1.2.1_amd64.deb
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_xenial/dist/dumb-init_1.2.1_amd64
* https://yelp-travis-artifacts.s3.amazonaws.com/dumb-init/125/itest_xenial/dist/dumb-init_1.2.1_amd64.deb
