### PR TITLE
Build for ppc64le via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,19 @@ services:
 addons:
     artifacts:
         target_paths:
-            - /dumb-init/${TRAVIS_BUILD_NUMBER}/${ITEST_TARGET}
+            - /dumb-init/${TRAVIS_BUILD_NUMBER}/${ITEST_TARGET}-${TRAVIS_OS_NAME}
         paths:
             - $(find dist -type f | tr "\n" ':')
 
-env:
-    matrix:
-        - ITEST_TARGET=itest_trusty
-        - ITEST_TARGET=itest_xenial
-        - ITEST_TARGET=itest_bionic
-        - ITEST_TARGET=itest_jessie
-        - ITEST_TARGET=itest_stretch
-        - ITEST_TARGET=itest_tox
+matrix:
+    include:
+        - env: ITEST_TARGET=itest_trusty
+        - env: ITEST_TARGET=itest_xenial
+        - env: ITEST_TARGET=itest_bionic
+        - env: ITEST_TARGET=itest_stretch
+        - env: ITEST_TARGET=itest_tox
+        - os: linux-ppc64le
+          env: ITEST_TARGET=itest_stretch
 
 script:
    - make "$ITEST_TARGET"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test:
 install-hooks:
 	tox -e pre-commit -- install -f --install-hooks
 
-ITEST_TARGETS = itest_trusty itest_xenial itest_bionic itest_jessie itest_stretch
+ITEST_TARGETS = itest_trusty itest_xenial itest_bionic itest_stretch
 
 .PHONY: itest $(ITEST_TARGETS)
 itest: $(ITEST_TARGETS)
@@ -77,7 +77,6 @@ itest: $(ITEST_TARGETS)
 itest_trusty: _itest-ubuntu-trusty
 itest_xenial: _itest-ubuntu-xenial
 itest_bionic: _itest-ubuntu-bionic
-itest_jessie: _itest-debian-jessie
 itest_stretch: _itest-debian-stretch
 
 itest_tox:


### PR DESCRIPTION
For #161 

I've removed `itest_jessie` from Travis because jessie is fairly old, and I think we're testing enough OSes at this point -- plus this one new build runs us one over the concurrency limit for Travis :)