### PR TITLE
Allow dumb-init to pause for n seconds when signal is received before forwarding/rewriting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ just add `--rewrite 15:3` on the command line.
 
 To drop a signal entirely, you can rewrite it to the special number `0`.
 
-
 #### Signal rewriting special case
 
 When running in setsid mode, it is not sufficient to forward
@@ -132,6 +131,18 @@ behavior by rewriting the signals back to their original values, if desired.
 One caveat with this feature: for job control signals (`SIGTSTP`, `SIGTTIN`,
 `SIGTTOU`), dumb-init will always suspend itself after receiving the signal,
 even if you rewrite it to something else.
+
+
+### Signal pausing
+
+dumb-init allows pausing incoming signals before proxying (or rewriting) them.
+This is useful in cases you're using a Docker supervisor (like Mesos or
+Kubernetes), because typically on those setups you need to install a `SIGTERM` handler whose responsibility is to delay the shutdown process to allow the
+ingress controller (like Traefik) to detect the Endpoints disappearing and
+taking the Service out of load-balancing rotation.
+
+For example, to pause the signal `SIGTERM` (number 15) for 10 seconds, just
+add `--pause 15:10` on the command line.
 
 
 ## Installing inside Docker containers

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-timeout = 5
+timeout = 15

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -109,3 +109,9 @@ def kill_if_alive(pid, signum=signal.SIGKILL):
     except OSError as ex:
         if ex.errno != errno.ESRCH:  # No such process
             raise
+
+def signum_and_time_from_stdout(stdout):
+    s = stdout.readline()
+    values = s.split(b':')
+    return int(values[0]), int(float(values[1]))
+

--- a/testing/print_signals.py
+++ b/testing/print_signals.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Print received signals to stdout.
+"""Print received signals with current timestamp to stdout.
 
 Since all signals are printed and otherwise ignored, you'll need to send
 SIGKILL (kill -9) to this process to actually end it.
@@ -27,8 +27,11 @@ def unbuffered_print(line):
 
 
 def print_signal(signum, _):
-    print_queue.append(signum)
+    msg = '{}:{}'.format(signum, time.time())
+    print_queue.append(msg)
 
+def signum_from_msg(msg):
+    return msg.split(':')[0]
 
 if __name__ == '__main__':
     for signum in CATCHABLE_SIGNALS:
@@ -39,9 +42,9 @@ if __name__ == '__main__':
     # loop forever just printing signals
     while True:
         if print_queue:
-            signum = print_queue.pop()
-            unbuffered_print(signum)
-
+            msg = print_queue.pop()
+            unbuffered_print(msg)
+            signum = signum_from_msg(msg)
             if signum == signal.SIGINT and last_signal == signal.SIGINT:
                 print('Received SIGINT twice, exiting.')
                 exit(0)

--- a/tests/child_processes_test.py
+++ b/tests/child_processes_test.py
@@ -11,6 +11,7 @@ from testing import is_alive
 from testing import kill_if_alive
 from testing import pid_tree
 from testing import sleep_until
+from testing import signum_and_time_from_stdout
 
 
 def spawn_and_kill_pipeline():
@@ -109,7 +110,8 @@ def test_all_processes_receive_term_on_exit_if_setsid():
     child_pid, child_stdout = spawn_process_which_dies_with_children()
 
     # print_signals should have received TERM
-    assert child_stdout.readline() == b'15\n'
+    received_signum, _ = signum_and_time_from_stdout(child_stdout)
+    assert received_signum == signal.SIGTERM
 
     os.kill(child_pid, signal.SIGKILL)
 
@@ -124,7 +126,8 @@ def test_processes_dont_receive_term_on_exit_if_no_setsid():
     # some other signals and ensure they were received (and TERM wasn't)
     for signum in [1, 2, 3]:
         os.kill(child_pid, signum)
-        assert child_stdout.readline() == str(signum).encode('ascii') + b'\n'
+        received_signum, _ = signum_and_time_from_stdout(child_stdout)
+        assert received_signum == signum
 
     os.kill(child_pid, signal.SIGKILL)
 

--- a/tests/pause_signals_test.py
+++ b/tests/pause_signals_test.py
@@ -1,0 +1,54 @@
+import os
+import signal
+import time
+
+import pytest
+
+from testing import NORMAL_SIGNALS
+from testing import print_signals
+from testing import process_state
+from testing import signum_and_time_from_stdout
+
+def signum_from_args(args):
+    return int(args[1].split(":")[0])
+
+def duration_from_args(args):
+    return int(args[1].split(":")[1])
+
+def rewrite_signum_from_args(args):
+    return int(args[3].split(":")[1])
+
+@pytest.mark.parametrize("pause_args", [
+    ("-p", "15:3"),
+    ("-p", "2:3"),
+])
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_pause_and_proxy_signals(pause_args):
+    """Ensure dumb-init can pause on signals before proxying them."""
+    signum = signum_from_args(pause_args)
+    duration = duration_from_args(pause_args)
+    with print_signals(pause_args) as (proc, _):
+        start_time = int(time.time())
+        proc.send_signal(signum)
+        received_signum, end_time = signum_and_time_from_stdout(proc.stdout)   
+        assert received_signum == signum
+        assert (end_time - start_time) >= duration
+
+
+@pytest.mark.parametrize("pause_rewrite_args", [
+    ("-p", "15:2", "-r", "15:3"),
+])
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_pause_and_proxy_signals_with_rewrite(pause_rewrite_args):
+    """Ensure dumb-init can pause on signals and rewrite them."""
+    signum = signum_from_args(pause_rewrite_args)
+    duration = duration_from_args(pause_rewrite_args)
+    rewrite_signum = rewrite_signum_from_args(pause_rewrite_args)
+    with print_signals(pause_rewrite_args) as (proc, _):
+        start_time = int(time.time())
+        proc.send_signal(signum)
+        received_signum, end_time = signum_and_time_from_stdout(proc.stdout)   
+        assert received_signum == rewrite_signum
+        assert (end_time - start_time) >= duration
+    
+ 


### PR DESCRIPTION
This PR allows dumb-init to pause incoming signals before proxying (or rewriting) them. This is useful in cases you're using a Docker supervisor (like Mesos or Kubernetes), because typically on those setups you need to install a `SIGTERM` handler whose responsibility is to delay the shutdown process to allow the ingress controller (like Traefik) to detect the Endpoints disappearing and taking the Service out of load-balancing rotation.

For example, to pause the signal SIGTERM (number 15) for 10 seconds, just add  `--pause 15:10` on the command line.