### PR TITLE
Nit: add braces around if

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -175,8 +175,9 @@ void parse_rewrite_signum(char *arg) {
 }
 
 void set_rewrite_to_sigstop_if_not_defined(int signum) {
-    if (signal_rewrite[signum] == -1)
+    if (signal_rewrite[signum] == -1) {
         signal_rewrite[signum] = SIGSTOP;
+    }
 }
 
 char **parse_command(int argc, char *argv[]) {


### PR DESCRIPTION
This PR adds braces around the `if` statement in `set_rewrite_to_sigstop_if_not_defined`. This is obviously a nitpick, but it adds greater consistency (all the other `if` statements have them) and prevents bugs from occuring based on the formatting (dangling statements that appear to be part of the `if` statement while they aren’t).

Cheers