### PR TITLE
Fix test on slow machines, increasing the sleep time

### DIFF
--- a/tests/child_processes_test.py
+++ b/tests/child_processes_test.py
@@ -80,7 +80,7 @@ def spawn_process_which_dies_with_children():
             # we need to sleep before the shell exits, or dumb-init might send
             # TERM to print_signals before it has had time to register custom
             # signal handlers
-            '{python} -m testing.print_signals & sleep 0.1'.format(
+            '{python} -m testing.print_signals & sleep 1'.format(
                 python=sys.executable,
             ),
         ),


### PR DESCRIPTION
The original sleep time is too short, the tests failed on
architectures like mips*, armhf. I think it's because the
python interpreter can't start in 0.1s.

After increasing the sleep time, it passed on most architectures
which Debian supports.

The result can be found at:
https://buildd.debian.org/status/logs.php?pkg=dumb-init
(compare the build result of 1.2.2-1.1 and 1.2.2-1)