### PR TITLE
build the package using the current uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,22 @@ RUN sed -E \
 # Install the bare minimum dependencies necessary for working with Debian
 # packages. Build dependencies should be added under "Build-Depends" inside
 # debian/control instead.
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN : \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         devscripts \
         equivs \
         lintian \
-    && rm -rf /var/lib/apt/lists/* && apt-get clean
-WORKDIR /mnt
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /tmp/mnt
 
-ENTRYPOINT apt-get update && \
-    mk-build-deps -i --tool 'apt-get --no-install-recommends -y' && \
-    make builddeb
+COPY debian/control /control
+RUN : \
+    && apt-get update \
+    && mk-build-deps --install --tool 'apt-get -y --no-install-recommends' /control \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT make builddeb

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ builddeb:
 .PHONY: builddeb-docker
 builddeb-docker: docker-image
 	mkdir -p dist
-	docker run -v $(PWD):/mnt dumb-init-build
+	docker run --user $$(id -u):$$(id -g) -v $(PWD):/tmp/mnt dumb-init-build
 
 .PHONY: docker-image
 docker-image:


### PR DESCRIPTION
this should hopefully fix the workspace cleaning noticed in #188

the main changes here:
- run `mk-build-deps` in the image
- run with `--user ...`
- move to `/mnt/tmp` so the debian machinery can write to `../` (`/tmp`)