### PR TITLE
Add support for signal "observers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ One caveat with this feature: for job control signals (`SIGTSTP`, `SIGTTIN`,
 even if you rewrite it to something else.
 
 
+### Signal "observing"
+
+dumb-init also allows executing an "observer" when a signal is received. An
+observer is nothing more than a script or executable that gets called as part of
+the signal-handling process, whether or not the signal is forwarded to the child
+process. You can provide a full path to an observer or let dumb-init search the
+`PATH`. The executable should not require or expect command line arguments (it
+will get none), but two environment variables will be provided,
+`DUMB_INIT_SIGNUM` and `DUMB_INIT_REPLACEMENT_SIGNUM`. They will contain the
+signal _numbers_, not names.
+
+An observer is specified as an optional third parameter to `-r/--rewrite`:
+`--rewrite 12:0:/path/to/observer`. To observe a signal while still passing it
+to the child process, simply replace a signal with itself: `--rewrite
+10:10:some_observer`.
+
+
 ## Installing inside Docker containers
 
 You have a few options for using `dumb-init`:
@@ -217,7 +234,7 @@ entrypoint. An "entrypoint" is a partial command that gets prepended to your
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # or if you use --rewrite or other cli flags
-# ENTRYPOINT ["dumb-init", "--rewrite", "2:3", "--"]
+# ENTRYPOINT ["dumb-init", "--rewrite", "2:3", "--rewrite", "10:10:observer_script", "--"]
 
 CMD ["/my/script", "--with", "--args"]
 ```

--- a/tests/execs_observers_test.py
+++ b/tests/execs_observers_test.py
@@ -1,0 +1,18 @@
+import os
+
+import pytest
+
+from testing import print_signals
+
+
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_execs_observers():
+    """Ensure dumb-init executes observers."""
+    with print_signals(('-r', '10:0:/bin/pwd', '-r', '12:12:pwd',)) as (proc, _):
+        proc.send_signal(10)
+        assert proc.stdout.readline() == '{}\n'.format(os.getcwd()).encode('ascii')
+        proc.send_signal(12)
+        assert (proc.stdout.readline() + proc.stdout.readline()) in (
+            '12\n{}\n'.format(os.getcwd()).encode('ascii'),
+            '{}\n12\n'.format(os.getcwd()).encode('ascii'),
+        )


### PR DESCRIPTION
- Add an optional third parameter to `-r/--rewrite` (`-r s:r[:observer]`) that specifies a script/executable that should be called when signal s is received (whether or not it is forwarded).
- The observer may be specified as a full path or `PATH` will be searched.
- The observer is called without any arguments, but the signal and replacement are provided by the `DUMB_INIT_SIGNUM` and `DUMB_INIT_REPLACEMENT_SIGNUM` environment variables, respectively.
- The intention is that the observer has no impact on dumb-init or the child process(es), for example if it exits with failure. It is simply an observer.

I desperately need this for a Nomad environment. When template files get automatically updated by service discovery or key-value changes, the only notification options are to restart the app/container (not good for this case) or signals; however, the process I am using does not have special signal-handling I need. So, I want to intercept the signal and execute a custom script ("observer").

Note: I am no expert with signal handling or fork+exec, so feel free to fix (and teach me)! The same goes for the tests I added which are very much a cut+paste job. :-)