### PR TITLE
Allow usage of signal names

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ which always sends a standard signal (e.g. SIGTERM). Some apps require a
 different stop signal in order to do graceful cleanup.
 
 For example, to rewrite the signal SIGTERM (number 15) to SIGQUIT (number 3),
-just add `--rewrite 15:3` on the command line.
+just add `--rewrite 15:3` or `--rewrite TERM:QUIT` on the command line. Signal
+names can be specified with or without the `SIG` prefix (e.g. `TERM` or
+`SIGTERM`). To see the mapping of signal numbers to names on the system in
+question, specify `-l/--list`.
 
 To drop a signal entirely, you can rewrite it to the special number `0`.
 
@@ -218,6 +221,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # or if you use --rewrite or other cli flags
 # ENTRYPOINT ["dumb-init", "--rewrite", "2:3", "--"]
+# ENTRYPOINT ["dumb-init", "--rewrite", "TERM:QUIT", "--"]
 
 CMD ["/my/script", "--with", "--args"]
 ```

--- a/tests/proxies_signals_test.py
+++ b/tests/proxies_signals_test.py
@@ -105,3 +105,21 @@ def test_ignored_signals_are_not_proxied():
         proc.send_signal(signal.SIGWINCH)
         proc.send_signal(signal.SIGHUP)
         assert proc.stdout.readline() == '{}\n'.format(signal.SIGHUP).encode('ascii')
+
+
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_signal_names():
+    """Ensure dumb-init can map signal names."""
+    rewrite_map = {
+        'TERM': 'QUIT',
+        'SIGINT': 0,
+        'WINCH': 0,
+    }
+    with print_signals(_rewrite_map_to_args(rewrite_map)) as (proc, _):
+        proc.send_signal(signal.SIGTERM)
+        proc.send_signal(signal.SIGINT)
+        assert proc.stdout.readline() == '{}\n'.format(signal.SIGQUIT).encode('ascii')
+
+        proc.send_signal(signal.SIGWINCH)
+        proc.send_signal(signal.SIGHUP)
+        assert proc.stdout.readline() == '{}\n'.format(signal.SIGHUP).encode('ascii')

--- a/tests/tty_test.py
+++ b/tests/tty_test.py
@@ -111,8 +111,8 @@ def test_sighup_sigcont_ignored_if_was_session_leader():
 
         output = readall(fd).decode('UTF-8')
 
-        assert 'Ignoring tty hand-off signal {}.'.format(signal.SIGHUP) in output
-        assert 'Ignoring tty hand-off signal {}.'.format(signal.SIGCONT) in output
+        assert 'Ignoring tty hand-off signal {} (HUP).'.format(signal.SIGHUP) in output
+        assert 'Ignoring tty hand-off signal {} (CONT).'.format(signal.SIGCONT) in output
 
-        assert '[dumb-init] Forwarded signal {} to children.'.format(signal.SIGHUP) in output
-        assert '[dumb-init] Forwarded signal {} to children.'.format(signal.SIGCONT) not in output
+        assert '[dumb-init] Forwarded signal {} (HUP) to children.'.format(signal.SIGHUP) in output
+        assert '[dumb-init] Forwarded signal {} (CONT) to children.'.format(signal.SIGCONT) not in output


### PR DESCRIPTION
- Adds a mapping of signal numbers to signal names based on the "most common" (subjective) signals.
- This allows the same config/script to be used on different platforms, for example: `-r TERM:QUIT` (`15:3` on Linux vs. `25:20` on OS X).
- Each entry is wrapped in a `#ifdef SIG<NAME>/#endif` pair in an attempt to make this implementation as portable as possible.
- Names can be specified with or without the `SIG` prefix, and numbers and names can be used in any combination: `-r 15:3`, `-r TERM:QUIT`, `-r SIGTERM:3`, `-r TERM:SIGQUIT`, etc.
- Corresponding `signum_to_signame()` and `signame_to_signum()` functions were added.
- A new `-l/--list` option shows the mapping in use on the current system/platform/OS.
- Debug output has been updated to include the signal name along with the number.

Fixes #87.

The build of the signal map is a bit lanky in dumb-init.c due to all of the `#ifdef/#endif`. It may be worth moving it into a separate file and using `extern`s and `#include`s, but I kept everything together for this first stab at it.