### PR TITLE
chdir to / in parent

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -326,6 +326,11 @@ int main(int argc, char *argv[]) {
     } else {
         /* parent */
         DEBUG("Child spawned with PID %d.\n", child_pid);
+        if (chdir("/") == -1) {
+             DEBUG("Unable to chdir(\"/\") (errno=%d %s)\n",
+                   errno,
+                   strerror(errno));
+        }
         for (;;) {
             int signum;
             sigwait(&all_signals, &signum);

--- a/tests/cwd_test.py
+++ b/tests/cwd_test.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+from subprocess import run, PIPE
+
+import pytest
+
+@pytest.mark.usefixtures('both_debug_modes', 'both_setsid_modes')
+def test_working_directories():
+    """The child process must start in the working directory in which
+    dumb-init was invoked, but dumb-init itself should not keep a
+    reference to that."""
+
+    # We need absolute path to dumb-init since we pass cwd=/tmp to get
+    # predictable output - so we can't rely on dumb-init being found
+    # in the "." directory.
+    dumb_init = os.path.realpath(shutil.which('dumb-init'))
+    proc = run((dumb_init,
+                'sh', '-c', 'readlink /proc/$PPID/cwd && readlink /proc/$$/cwd'),
+               cwd="/tmp", stdout=PIPE, stderr=PIPE)
+
+    assert proc.returncode == 0
+    assert proc.stdout == b'/\n/tmp\n'


### PR DESCRIPTION
There's no reason the dumb-init process should hold on to a reference
to the original cwd (but of course the child must be spawned with that
cwd). One example where that can be problematic:

```
# Terminal 1
$ mkdir -p /tmp/d/e
$ sudo mount --make-shared -t tmpfs tmpfs /tmp/d/e

# Terminal 2
$ docker run -v /tmp/d:/tmp/d:rshared --rm -ti --workdir /tmp/d/e some-image-with-dumb-init bash
root@922ef180b49a:/tmp/d/e# cd ..
root@922ef180b49a:/tmp/d# ls -l /proc/*/cwd
lrwxrwxrwx 1 root root 0 Oct  1 11:25 /proc/1/cwd -> /tmp/d/e
lrwxrwxrwx 1 root root 0 Oct  1 11:25 /proc/6/cwd -> /tmp/d
lrwxrwxrwx 1 root root 0 Oct  1 11:25 /proc/self/cwd -> /tmp/d
lrwxrwxrwx 1 root root 0 Oct  1 11:25 /proc/thread-self/cwd -> /tmp/d

# Terminal 1
$ sudo umount /tmp/d/e
umount: /tmp/d/e: target is busy.
```

i.e., the application inside the container has already let go of its
reference, but the host is not able to unmount /tmp/d/e because the
container's pid 1 still has one.

As for a test case, the 'docker run --workdir' could be emulated by
something like

  sh -c "cd /tmp/d/e; exec $PWD/dumb-init bash -i"

but one would still need root to do the mount and umount.