### PR TITLE
Travis-ci: updated  support for ppc64le in latest way and added for i…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
         - env: ITEST_TARGET=itest_bionic
         - env: ITEST_TARGET=itest_buster
         - env: ITEST_TARGET=itest_tox
-        - arch: ppc64le 
-          env: ITEST_TARGET=itest_tox
         - arch: ppc64le
           env: ITEST_TARGET=itest_buster
         - arch: arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,16 @@ matrix:
         - env: ITEST_TARGET=itest_bionic
         - env: ITEST_TARGET=itest_buster
         - env: ITEST_TARGET=itest_tox
-        - os: linux-ppc64le
+        - arch: ppc64le 
+          env: ITEST_TARGET=itest_tox
+        - arch: ppc64le
           env: ITEST_TARGET=itest_buster
         - arch: arm64
           env: ITEST_TARGET=itest_buster
         - arch: s390x
           env: ITEST_TARGET=itest_buster
     allow_failures:
-        - os: linux-ppc64le
+        - arch: ppc64le
           env: ITEST_TARGET=itest_buster
         - arch: arm64
           env: ITEST_TARGET=itest_buster


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/dumb-init/builds/188136243 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!