### PR TITLE
Ensure VERSION is NUL-terminated

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -126,7 +126,7 @@ void handle_signal(int signum) {
 
 void print_help(char *argv[]) {
     fprintf(stderr,
-        "dumb-init v%s"
+        "dumb-init v%*s"
         "Usage: %s [option] command [[arg] ...]\n"
         "\n"
         "dumb-init is a simple process supervisor that forwards signals to children.\n"
@@ -144,7 +144,7 @@ void print_help(char *argv[]) {
         "   -V, --version        Print the current version and exit.\n"
         "\n"
         "Full help is available online at https://github.com/Yelp/dumb-init\n",
-        VERSION,
+        VERSION_len, VERSION,
         argv[0]
     );
 }
@@ -199,7 +199,7 @@ char **parse_command(int argc, char *argv[]) {
                 debug = 1;
                 break;
             case 'V':
-                fprintf(stderr, "dumb-init v%s", VERSION);
+                fprintf(stderr, "dumb-init v%*s", VERSION_len, VERSION);
                 exit(0);
             case 'c':
                 use_setsid = 0;


### PR DESCRIPTION
The `VERSION` variable is referenced in two places inside `dumb-init.c`: in the `print_help()` function, and in `parse_command()`, when the `--version` option is passed:
```c
void print_help(char *argv[]) {
    fprintf(stderr,
        "dumb-init v%s"
        "Usage: %s [option] command [[arg] ...]\n"
// (snip)
        "Full help is available online at https://github.com/Yelp/dumb-init\n",
        VERSION,
        argv[0]
    );
}

// inside parse_command()
    case 'V':
        fprintf(stderr, "dumb-init v%s", VERSION);
        exit(0);
```
In both of these cases, `VERSION` is used as an argument to `fprintf()`, to be formatted with `%s`. The man page for `fprintf(3)` says this about the `%s` conversion specifier:
> The const char *  argument  is  expected to be a pointer to an array of character type (pointer to a string).  Characters from the array are written up to (but not including)  a  terminating  null  byte ('\0');

However, the way `VERSION` is currently generated, it does **NOT** contain the terminating null byte.
```
unsigned char VERSION[] = {
  0x31, 0x2e, 0x32, 0x2e, 0x32, 0x0a
};
```
This patch changes the way `VERSION.h` is generated, to ensure that `VERSION` is a NUL-terminated string.