### PR TITLE
Use "%.*s" when printing VERSION

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -126,7 +126,7 @@ void handle_signal(int signum) {
 
 void print_help(char *argv[]) {
     fprintf(stderr,
-        "dumb-init v%*s"
+        "dumb-init v%.*s"
         "Usage: %s [option] command [[arg] ...]\n"
         "\n"
         "dumb-init is a simple process supervisor that forwards signals to children.\n"
@@ -199,7 +199,7 @@ char **parse_command(int argc, char *argv[]) {
                 debug = 1;
                 break;
             case 'V':
-                fprintf(stderr, "dumb-init v%*s", VERSION_len, VERSION);
+                fprintf(stderr, "dumb-init v%.*s", VERSION_len, VERSION);
                 exit(0);
             case 'c':
                 use_setsid = 0;


### PR DESCRIPTION
Sorry for the déjà vu. So, I submitted PR #213 and checked that my patch works. After re-writing the patch as suggested, I did not, however, attempt to re-build the app again... and what do you know, the new patch was wrong.

The patch from #213 replaced the `%s` conversion specifier with `%*s`. However, the `%*s` conversion specifier defines the field width, i.e. **minimum** number of characters to print. The proper solution is to use `%.*s` (note the dot), which defines the precision, i.e. the **maximum** number of printed characters.

Again, sorry for not verifying the earlier patch. This one works fine (the Fedora package on s390x builds and passes the test suite).