### PR TITLE
setup.py: Add license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,4 +134,10 @@ setup(
         'install_cexe': install_cexe,
     },
     distclass=ExeDistribution,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: MIT License',
+        'Intended Audience :: Developers',
+        'Programming Language :: C',
+    ],
 )


### PR DESCRIPTION
Adds a few PyPi classifiers. In particular, the License classifier should avoid `pip-licenses` reporting the license as `UNKNOWN`.