### PR TITLE
requirements-dev.txt: add py (for pytest >= 7.2.0)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest
 # We should fix this by not depending on the system pytest/python packages at
 # some point.
 pytest-timeout<2.0.0
+py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pre-commit>=0.5.0
+py
 pytest
 # TODO: This pin is to work around an issue where the system pytest is too old.
 # We should fix this by not depending on the system pytest/python packages at
 # some point.
 pytest-timeout<2.0.0
-py


### PR DESCRIPTION
For pytest >= 7.2.0, the 'py' library is no longer installed.

Fixes:
https://github.com/Yelp/dumb-init/issues/286

Signed-off-by: Tim Orling <tim.orling@konsulko.com>