### PR TITLE
Add riscv64 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,23 +8,28 @@ jobs:
             matrix:
                 include:
                     - arch: amd64
-                      manylinux_arch: x86_64
+                      manylinux_arch: manylinux2014_x86_64
                       docker_image: debian:bookworm
 
                     - arch: arm64
-                      manylinux_arch: aarch64
+                      manylinux_arch: manylinux2014_aarch64
                       docker_image: arm64v8/debian:bookworm
 
                     - arch: ppc64le
-                      manylinux_arch: ppc64le
+                      manylinux_arch: manylinux2014_ppc64le
                       docker_image: ppc64le/debian:bookworm
 
                     - arch: s390x
-                      manylinux_arch: s390x
+                      manylinux_arch: manylinux2014_s390x
                       docker_image: s390x/debian:bookworm
+
+                    - arch: riscv64
+                      manylinux_arch: manylinux_2_39_riscv64
+                      docker_image: riscv64/debian:trixie
 
         env:
             BASE_IMAGE: ${{ matrix.docker_image }}
+            TARGETARCH: ${{ matrix.arch }}
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,19 +9,19 @@ jobs:
                 include:
                     - arch: amd64
                       manylinux_arch: x86_64
-                      docker_image: debian:buster
+                      docker_image: debian:bookworm
 
                     - arch: arm64
                       manylinux_arch: aarch64
-                      docker_image: arm64v8/debian:buster
+                      docker_image: arm64v8/debian:bookworm
 
                     - arch: ppc64le
                       manylinux_arch: ppc64le
-                      docker_image: ppc64le/debian:buster
+                      docker_image: ppc64le/debian:bookworm
 
                     - arch: s390x
                       manylinux_arch: s390x
-                      docker_image: s390x/debian:buster
+                      docker_image: s390x/debian:bookworm
 
         env:
             BASE_IMAGE: ${{ matrix.docker_image }}
@@ -48,7 +48,7 @@ jobs:
             - name: Test built Debian package
               # XXX: This uses the clean base image (not the build one) to make
               # sure it installs in a clean image without any hidden dependencies.
-              run: docker run --rm -v $(pwd):/mnt:rw ${{ matrix.docker_image }} /mnt/ci/docker-deb-test
+              run: docker run --platform linux/${{ matrix.arch }} --rm -v $(pwd):/mnt:rw ${{ matrix.docker_image }} /mnt/ci/docker-deb-test
 
             - name: Build wheels
               run: sudo make python-dists-${{ matrix.manylinux_arch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: push
 jobs:
     build-and-test:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,9 @@ jobs:
             - name: Build wheels
               run: sudo make python-dists-${{ matrix.manylinux_arch }}
 
+            - name: Compute sha256sums
+              run: sha256sum dist/* | sudo tee dist/sha256sums
+
             - name: Upload build artifacts
               uses: actions/upload-artifact@v4
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
               run: sudo make python-dists-${{ matrix.manylinux_arch }}
 
             - name: Upload build artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ matrix.arch }}
                   path: dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.0
+-   repo: https://github.com/hhatto/autopep8
+    rev: v2.3.2
     hooks:
     -   id: autopep8
 -   repo: https://github.com/pycqa/flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:buster
+ARG BASE_IMAGE=debian:bookworm
 FROM $BASE_IMAGE
 
 LABEL maintainer="Chris Kuehl <ckuehl@yelp.com>"
@@ -13,7 +13,6 @@ RUN : \
         devscripts \
         equivs \
         lintian \
-        python3-distutils \
         python3-setuptools \
         python3-pip \
     && apt-get clean \

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,19 @@ release: python-dists
 		> sha256sums
 
 .PHONY: python-dists
-python-dists: python-dists-x86_64 python-dists-aarch64 python-dists-ppc64le python-dists-s390x
+python-dists: python-dists-manylinux2014_x86_64 python-dists-manylinux2014_aarch64 python-dists-manylinux2014_ppc64le python-dists-manylinux2014_s390x python-dists-manylinux_2_39_riscv64
 
 .PHONY: python-dists-%
 python-dists-%: VERSION.h
 	python setup.py sdist
+	if test -f dist/dumb-init-$(VERSION).tar.gz; then \
+		mv dist/dumb-init-$(VERSION).tar.gz dist/dumb_init-$(VERSION).tar.gz; \
+	fi
 	docker run \
+		$(if $(TARGETARCH),--platform linux/$(TARGETARCH)) \
 		--user $$(id -u):$$(id -g) \
 		-v `pwd`/dist:/dist:rw \
-		quay.io/pypa/manylinux2014_$*:latest \
+		quay.io/pypa/$*:latest \
 		bash -exc ' \
 			/opt/python/cp38-cp38/bin/pip wheel --wheel-dir /tmp /dist/*.tar.gz && \
 			auditwheel repair --wheel-dir /dist /tmp/*.whl --wheel-dir /dist \
@@ -61,7 +65,12 @@ builddeb-docker: docker-image
 
 .PHONY: docker-image
 docker-image:
-	docker build $(if $(BASE_IMAGE),--build-arg BASE_IMAGE=$(BASE_IMAGE)) -t dumb-init-build .
+	docker buildx build \
+		$(if $(TARGETARCH),--platform linux/$(TARGETARCH)) \
+		$(if $(BASE_IMAGE),--build-arg BASE_IMAGE=$(BASE_IMAGE)) \
+		--load \
+		-t dumb-init-build \
+		.
 
 .PHONY: test
 test:

--- a/ci/docker-deb-test
+++ b/ci/docker-deb-test
@@ -1,6 +1,9 @@
 #!/bin/bash -eux
 set -o pipefail
 
+# Allow pip from modifying the system packages
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
 apt-get update
 apt-get -y --no-install-recommends install python3-pip procps
 

--- a/ci/docker-python-test
+++ b/ci/docker-python-test
@@ -1,6 +1,9 @@
 #!/bin/bash -eux
 set -euo pipefail
 
+# Allow pip from modifying the system packages
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
 cd /mnt
 
 python3 setup.py clean

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
 pre-commit>=0.5.0
 pytest
-# TODO: This pin is to work around an issue where the system pytest is too old.
-# We should fix this by not depending on the system pytest/python packages at
-# some point.
-pytest-timeout<2.0.0
+pytest-timeout


### PR DESCRIPTION
This PR adds support for RISC-V following the recent release of Debian Trixie on riscv64 as a stable target [1]. This also unblocks packaging and distributing Gitlab Runners on riscv64.

[1] https://www.debian.org/releases/trixie/